### PR TITLE
Remove obsolete package fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
-  "name": "root",
+  "name": "@tvkitchen/appliances",
   "private": true,
-  "version": "1.0.0",
-  "description": "A template for TV Kitchen Appliances.",
-  "main": "src/index.js",
   "repository": "git@github.com:tvkitchen/tvka-template.git",
   "author": "Bad Idea Factory <biffuddotcom@biffud.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description
This PR removes package fields from the root that don't make sense any longer for a monorepo root.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #20 