### PR TITLE
Create initial CCExtractorAppliance

### DIFF
--- a/packages/ccextractor/CHANGELOG.md
+++ b/packages/ccextractor/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for @tvkitchen/appliance-ccextractor
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- Initial implementation of the `CCExtractorAppliance`
+
+### Changed

--- a/packages/ccextractor/README.md
+++ b/packages/ccextractor/README.md
@@ -1,0 +1,16 @@
+# TV Kitchen CCExtractor Appliance
+
+---
+inputTypes: STREAM.CONTAINER
+outputTypes: TEXT.ATOM
+---
+
+The Caption appliance consumes `STREAM.CONTAINER` payloads and produces `TEXT.ATOM` payloads which reflect the closed captions of the stream.
+
+## Dependencies
+
+In order to use this appliance, you must have [ccextractor](https://www.ccextractor.org/) installed on your system, and the `ccextractor` command must work.
+
+## About the TV Kitchen
+
+TV Kitchen is a project of [Bad Idea Factory](https://biffud.com).  Learn more at [the TV Kitchen project site](https://tv.kitchen).

--- a/packages/ccextractor/package.json
+++ b/packages/ccextractor/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tvkitchen/appliance-ccextractor",
+  "description": "Extracts captions from MPEG-TS Payloads using CCExtractor.",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tvkitchen/appliances.git",
+    "directory": "packages/ccextractor"
+  },
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "dependencies": {
+    "@tvkitchen/appliance-core": "0.3.0",
+    "@tvkitchen/base-classes": "^1.3.0",
+    "@tvkitchen/base-constants": "^1.0.1",
+    "command-exists": "^1.2.9"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/ccextractor/src/CCExtractorAppliance.js
+++ b/packages/ccextractor/src/CCExtractorAppliance.js
@@ -1,0 +1,90 @@
+import { spawn } from 'child_process'
+import commandExists from 'command-exists'
+import {
+	PayloadArray,
+} from '@tvkitchen/base-classes'
+import {
+	dataTypes,
+	applianceEvents,
+} from '@tvkitchen/base-constants'
+import { AbstractAppliance } from '@tvkitchen/appliance-core'
+import {
+	parseCcExtractorLines,
+	convertCcExtractorLineToPayload,
+} from './utils/ccextractor'
+
+class CaptionAppliance extends AbstractAppliance {
+	ccExtractorProcess = null
+
+	mostRecentLine = null
+
+	static getInputTypes = () => [dataTypes.STREAM.CONTAINER]
+
+	static getOutputTypes = () => [dataTypes.TEXT.ATOM]
+
+	/**
+	 * Process a line of ccextractor output and emit new Payloads as appropriate.
+	 *
+	 * @param  {Buffer} data The raw output from a ccextractor process.
+	 * @return {null}
+	 */
+	handleCcExtractorData = (data) => {
+		const lines = parseCcExtractorLines(data.toString())
+		const payloads = lines
+			.filter((line) => line.text !== '')
+			.map((line) => {
+				const previousLine = this.mostRecentLine
+				this.mostRecentLine = line
+				return convertCcExtractorLineToPayload(line, previousLine)
+			})
+			.filter((payload) => payload.data !== '')
+		payloads.forEach((payload) => this.emit(applianceEvents.PAYLOAD, payload))
+	}
+
+	/** @inheritdoc */
+	audit = async () => {
+		let passed = true
+		if (!commandExists.sync('ccextractor')) {
+			passed = false
+			this.logger.error('CCExtractor must be installed and the `ccextractor` command must work.')
+		}
+		return passed
+	}
+
+	/** @inheritdoc */
+	start = async () => {
+		this.emit(applianceEvents.STARTING)
+		this.ccExtractorProcess = spawn('ccextractor', [
+			'-stdout',
+			'--stream',
+			'-out=txt',
+			'-dru', // output characters as they arrive
+			'-ru1', // only render the current line
+			'-customtxt', '1100100', // start time, end time, use relative timestamp
+			'-',
+		])
+		this.ccExtractorProcess.stdout.on('data', this.handleCcExtractorData)
+		this.emit(applianceEvents.READY)
+	}
+
+	/** @inheritdoc */
+	stop = async () => {
+		this.emit(applianceEvents.STOPPING)
+		if (this.ccExtractorProcess !== null) {
+			this.ccExtractorProcess.kill()
+		}
+		this.emit(applianceEvents.STOPPED)
+	}
+
+	/** @inheritdoc */
+	invoke = async (payloadArray) => {
+		const unprocessedPayloadArray = new PayloadArray()
+		const streamContainerPayloads = payloadArray.filterByType(dataTypes.STREAM.CONTAINER)
+		streamContainerPayloads.toArray().forEach((payload) => {
+			this.ccExtractorProcess.stdin.write(payload.data)
+		})
+		return unprocessedPayloadArray
+	}
+}
+
+export default CaptionAppliance

--- a/packages/ccextractor/src/CCExtractorLine.js
+++ b/packages/ccextractor/src/CCExtractorLine.js
@@ -1,0 +1,16 @@
+
+class CCExtractorLine {
+	constructor({
+		start = 0,
+		end = 0,
+		text = '',
+	} = {}) {
+		Object.assign(this, {
+			start,
+			end,
+			text,
+		})
+	}
+}
+
+export default CCExtractorLine

--- a/packages/ccextractor/src/__test__/CCExtraactorLine.unit.test.js
+++ b/packages/ccextractor/src/__test__/CCExtraactorLine.unit.test.js
@@ -1,0 +1,22 @@
+import CCExtractorLine from '../CCExtractorLine'
+
+describe('CCExtractorLine', () => {
+	describe('constructor', () => {
+		it('should construct properly with no parameters', () => {
+			const line = new CCExtractorLine()
+			expect(line.start).toBe(0)
+			expect(line.end).toBe(0)
+			expect(line.text).toBe('')
+		})
+		it('should construct with values', () => {
+			const line = new CCExtractorLine({
+				start: 15,
+				end: 30,
+				text: 'banana',
+			})
+			expect(line.start).toBe(15)
+			expect(line.end).toBe(30)
+			expect(line.text).toBe('banana')
+		})
+	})
+})

--- a/packages/ccextractor/src/__test__/CCExtractorAppliance.unit.test.js
+++ b/packages/ccextractor/src/__test__/CCExtractorAppliance.unit.test.js
@@ -1,0 +1,26 @@
+import { dataTypes } from '@tvkitchen/base-constants'
+import commandExists from 'command-exists'
+import CCExtractorAppliance from '..'
+
+jest.mock('command-exists')
+
+describe('CCExtractorAppliance', () => {
+	describe('getInputTypes', () => {
+		expect(CCExtractorAppliance.getInputTypes()).toContain(dataTypes.STREAM.CONTAINER)
+	})
+
+	describe('audit', () => {
+		it('should log an error and return false if CCExtractor is not installed', async () => {
+			commandExists.sync.mockReturnValue(false)
+			const appliance = new CCExtractorAppliance()
+			const loggerSpy = jest.spyOn(appliance.logger, 'error')
+			expect(await appliance.audit()).toBe(false)
+			expect(loggerSpy).toHaveBeenCalledTimes(1)
+		})
+		it('should return true if CCExtractor is installed', async () => {
+			commandExists.sync.mockReturnValue(true)
+			const appliance = new CCExtractorAppliance()
+			expect(await appliance.audit()).toBe(true)
+		})
+	})
+})

--- a/packages/ccextractor/src/index.js
+++ b/packages/ccextractor/src/index.js
@@ -1,0 +1,3 @@
+import CCExtractorAppliance from './CCExtractorAppliance'
+
+export default CCExtractorAppliance

--- a/packages/ccextractor/src/utils/__test__/ccextractor.unit.test.js
+++ b/packages/ccextractor/src/utils/__test__/ccextractor.unit.test.js
@@ -1,0 +1,106 @@
+import { Payload } from '@tvkitchen/base-classes'
+import {
+	parseCcExtractorLine,
+	parseCcExtractorLines,
+	ccExtractorTimestampToMs,
+	convertCcExtractorLineToPayload,
+} from '../ccextractor'
+import CCExtractorLine from '../../CCExtractorLine'
+
+describe('ccextractor utils #unit', () => {
+	describe('parseCcExtractorLine', () => {
+		it('should properly parse a valid line', () => {
+			const ccExtractorLine = parseCcExtractorLine('00:00:56,723|00:00:58,591|CALLED BILL BARR THE IRAN/CONTRA')
+			expect(ccExtractorLine).toEqual(new CCExtractorLine({
+				start: 56723,
+				end: 58591,
+				text: 'CALLED BILL BARR THE IRAN/CONTRA',
+			}))
+		})
+		it('should throw an error on an invalid line', () => {
+			expect(() => parseCcExtractorLine('lol this is not valid')).toThrow()
+		})
+	})
+	describe('parseCcExtractorLines', () => {
+		it('should properly parse a valid lines', () => {
+			const ccExtractorLines = parseCcExtractorLines(`00:00:58,892|00:00:59,726|CLEANUP GUY AND IF YOU L
+00:00:58,892|00:00:59,759|CLEANUP GUY AND IF YOU LOO`)
+			expect(ccExtractorLines).toEqual([
+				new CCExtractorLine({
+					start: 58892,
+					end: 59726,
+					text: 'CLEANUP GUY AND IF YOU L',
+				}),
+				new CCExtractorLine({
+					start: 58892,
+					end: 59759,
+					text: 'CLEANUP GUY AND IF YOU LOO',
+				}),
+			])
+		})
+		it('should skip invalid lines', () => {
+			expect(parseCcExtractorLines('lol this is not valid'))
+				.toEqual([])
+			expect(parseCcExtractorLines(`00:00:58,892|00:00:59,726|CLEANUP GUY AND IF YOU L
+lol this is not valid`))
+				.toEqual([
+					new CCExtractorLine({
+						start: 58892,
+						end: 59726,
+						text: 'CLEANUP GUY AND IF YOU L',
+					}),
+				])
+		})
+	})
+	describe('ccExtractorTimestampToMs', () => {
+		it('should properly parse ms', () => {
+			expect(ccExtractorTimestampToMs('00:00:00,723')).toBe(723)
+		})
+		it('should properly parse seconds', () => {
+			expect(ccExtractorTimestampToMs('00:00:56,000')).toBe(56000)
+		})
+		it('should properly parse minutes', () => {
+			expect(ccExtractorTimestampToMs('00:10:00,000')).toBe(600000)
+		})
+		it('should properly parse hours', () => {
+			expect(ccExtractorTimestampToMs('11:00:00,000')).toBe(39600000)
+		})
+		it('should properly parse everything', () => {
+			expect(ccExtractorTimestampToMs('90:11:14,123')).toBe(324674123)
+		})
+	})
+	describe('convertCcExtractorLineToPayload', () => {
+		it('should convert a single line', () => {
+			const ccExtractorLine = new CCExtractorLine({
+				start: 58892,
+				end: 59726,
+				text: 'CLEANUP GUY AND IF YOU L',
+			})
+			const payload = convertCcExtractorLineToPayload(ccExtractorLine)
+			const targetPayload = new Payload({
+				position: 58892,
+				duration: 834,
+				data: 'CLEANUP GUY AND IF YOU L',
+			})
+			expect(payload.position).toEqual(targetPayload.position)
+			expect(payload.duration).toEqual(targetPayload.duration)
+			expect(payload.data).toEqual(targetPayload.data)
+		})
+		it('should convert the diff between two lines', () => {
+			const previousLine = new CCExtractorLine({
+				start: 58892,
+				end: 59726,
+				text: 'CLEANUP GUY AND IF YOU L',
+			})
+			const newLine = new CCExtractorLine({
+				start: 58892,
+				end: 59759,
+				text: 'CLEANUP GUY AND IF YOU LOO',
+			})
+			const payload = convertCcExtractorLineToPayload(newLine, previousLine)
+			expect(payload.position).toEqual(59726)
+			expect(payload.duration).toEqual(33)
+			expect(payload.data).toEqual('OO')
+		})
+	})
+})

--- a/packages/ccextractor/src/utils/__test__/string.unit.test.js
+++ b/packages/ccextractor/src/utils/__test__/string.unit.test.js
@@ -1,0 +1,15 @@
+import { getDiff } from '../string'
+
+describe('string utils #unit', () => {
+	describe('getDiff', () => {
+		it('should return an empty string if no difference exists', () => {
+			expect(getDiff('apple', 'apple')).toBe('')
+		})
+		it('should return the different characters if there is some overlap', () => {
+			expect(getDiff('boxcar', 'box')).toBe('car')
+		})
+		it('should return the original string if there is no similarity', () => {
+			expect(getDiff('apple', 'orange')).toBe('apple')
+		})
+	})
+})

--- a/packages/ccextractor/src/utils/ccextractor.js
+++ b/packages/ccextractor/src/utils/ccextractor.js
@@ -1,0 +1,88 @@
+import { Payload } from '@tvkitchen/base-classes'
+import CCExtractorLine from '../CCExtractorLine'
+import { getDiff } from './string'
+
+/**
+ * Converts a ccextractor timestamp (HH:MM:SS,MS) to milliseconds.
+ *
+ * @param  {String} str The string timestamp in ccextractor's timestamp format.
+ * @return {Number}     The number of milliseconds represented by that timestamp.
+ */
+export const ccExtractorTimestampToMs = (str) => {
+	const [
+		timestamp,
+		milliseconds,
+	] = str.split(',')
+	const [
+		hours,
+		minutes,
+		seconds,
+	] = timestamp.split(':')
+	return (parseInt(hours, 10) * 3600000
+		+ parseInt(minutes, 10) * 60000
+		+ parseInt(seconds, 10) * 1000
+		+ parseInt(milliseconds, 10)
+	)
+}
+
+/**
+ * Parses a line of output from CCExtractor using our custom configured format.
+ *
+ * The format parsed is assuming the following CCExtractor parameters
+ *
+ * - `-out=txt`
+ * - `-customtxt 1100100`
+ *
+ * @param  {String} line     The raw output to be parsed.
+ * @return {CCExtractorLine} The parsed line.
+ */
+export const parseCcExtractorLine = (line) => {
+	const parts = line.split('|')
+	if (parts.length !== 3) {
+		throw new Error('Cannot parse an invalid CCExtractor line')
+	}
+	return new CCExtractorLine({
+		start: ccExtractorTimestampToMs(parts[0]),
+		end: ccExtractorTimestampToMs(parts[1]),
+		text: parts[2],
+	})
+}
+
+/**
+ * Parses ccextractor output containing multiple lines using our custom configured format.
+ *
+ * See the documentation of `parseLine` for more information on that format.
+ *
+ * @param  {String} str        The string to be parsed.
+ * @return {CCExtractorLine[]} The parsed lines.
+ */
+export const parseCcExtractorLines = (str) => str
+	.replace(/\r\n/g, '\n')
+	.split('\n')
+	.map((line) => {
+		try {
+			return parseCcExtractorLine(line)
+		} catch (err) {
+			return null
+		}
+	})
+	.filter((line) => line !== null)
+
+/**
+ * Takes a pair of CCExtractorLines and generates a payload based on their
+ * differences.
+ *
+ * @param  {CCExtractorLine} line         [description]
+ * @param  {CCExtractorLine} previousLine [description]
+ * @return {[type]}      [description]
+ */
+export const convertCcExtractorLineToPayload = (line, previousLine = null) => {
+	const newCharacters = getDiff(line.text, previousLine ? previousLine.text : '')
+	const start = previousLine ? previousLine.end : line.start
+	const { end } = line
+	return new Payload({
+		data: newCharacters,
+		position: start,
+		duration: end - start,
+	})
+}

--- a/packages/ccextractor/src/utils/string.js
+++ b/packages/ccextractor/src/utils/string.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * Returns the difference between two strings.
+ *
+ * @param  {String} strA The string whose differences are being identified.
+ * @param  {String} strB The base string being detected
+ * @return {String}      The difference
+ */
+export const getDiff = (strA, strB) => strA.split(strB).join('')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,12 +1028,24 @@
   dependencies:
     type-detect "4.0.8"
 
+"@tvkitchen/appliance-core@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/appliance-core/-/appliance-core-0.3.0.tgz#eab8e9b882dc9d46e56b586427b0ccce14f8d38d"
+  integrity sha512-s6muzgQNGzCVVZJEKP4mQVVgKu1RmbAwbRw4u6zutE5uRodrK18xTaJRP5JXJ8jYW6JmBRMrGUfhBAPw0xdpCA==
+  dependencies:
+    "@tvkitchen/base-classes" "^1.3.0"
+    "@tvkitchen/base-constants" "^1.2.0"
+    "@tvkitchen/base-errors" "^1.0.1"
+    "@tvkitchen/base-interfaces" "4.0.0-alpha.2"
+    command-exists "^1.2.9"
+    ts-demuxer "^1.0.0"
+
 "@tvkitchen/base-classes@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
   integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
 
-"@tvkitchen/base-constants@1.2.0", "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
+"@tvkitchen/base-constants@1.2.0", "@tvkitchen/base-constants@^1.0.1", "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-constants/-/base-constants-1.2.0.tgz#020246bd1ff700e67066eea2e708dc5254cbcb9d"
   integrity sha512-9oyAYcMwWH1NiM9kFJ6yxameRBb58gq3/NCPBcXxVRe8IdHnQ3XKVC0fw0J3pfeOgOHayEeVTtEcSx4FlhilOw==


### PR DESCRIPTION
## Description
This PR adds the CCExtractorAppliance, which consumes STREAM.CONTAINER payloads and emits
TEXT.ATOM payloads.

It relies on the `CCExtractor` command line tool in order to run, and it attempts to parse the smallest possible "new" data from the CCExtractor output.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
0. `yarn install`
1. `yarn test`

Without a working TV Kitchen countertop it is hard to test this appliance in full yet.

## Deploy Notes
None.

## Related Issues
Resolves #16

