### PR TITLE
Add AbstractVideoIngestionAppliance

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -8,5 +8,6 @@
       "statements": 100
     }
   },
+  "silent": true,
   "testPathIgnorePatterns": ["<rootDir>/packages/(?:.+?)/lib/"]
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,15 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Initial implementation of the `AbstractVideoIngestionAppliance`.
 
+### Changed
+- Increase the `base-interfaces` version dependency to `4.0.0-alpha.2`.
+ 
 ## [0.1.0] - 2020-08-23
 ### Added
-- Initial implementation of the AbstractAppliance.
+- Initial implementation of the `AbstractAppliance`.
 - Add the `base-constants` dependency for applianceEvents.
 - Add `emit` method to AbstractAppliance.
 
 ### Changed
-- Increase the `base-classes` version dependency to 1.3.0.
-- Increase the `base-interfaces` version dependency to 3.0.0.
+- Increase the `base-classes` version dependency to `1.3.0`.
+- Increase the `base-interfaces` version dependency to `3.0.0`.
 
 [0.1.0]: https://github.com/tvkitchen/appliances/releases/tag/@tvkitchen/appliance-core@0.1.0

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,6 +8,8 @@ This package has some supporting classes, but the content that will be relevant 
 
 * `AbstractAppliance` is a class which all TV Kitchen Appliances should extend and implement.
 
+* `AbstractVideoIngestionAppliance` is a class that converts an arbitrary video input stream into properly decorated STREAM.CONTAINER Payloads.
+
 ## Implementing an Abstract Appliance
 
 An implemented TV Kitchen Appliance must override the following methods which are outlined in the [IAppliance interface](https://github.com/tvkitchen/base/blob/master/packages/interfaces/src/IAppliance.js):
@@ -16,6 +18,14 @@ An implemented TV Kitchen Appliance must override the following methods which ar
 2. `getOutputTypes`: returns an array of strings that represent the data types that the appliance produces.
 3. `isValidPayload`: returns a boolean indicating if a given `Payload` (instance of data) meets the conditions of the appliance.
 4. `invoke`: will actually process the data that has been collected by the appliance so far.
+
+## Implementing an Abstract Video Ingestion Appliance
+
+An implemented TV Kitchen Video Ingestion Appliance must override the following methods:
+
+1. `getInputStream`: returns an ReadbleStream to a video.
+
+If you override `audit` please be sure to call super.audit() as well.
 
 ## About the TV Kitchen
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tvkitchen/appliance-core",
   "description": "Core classes for use by TV Kitchen Appliances",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tvkitchen/appliances.git",
@@ -12,11 +12,11 @@
   "module": "src/index.js",
   "dependencies": {
     "@tvkitchen/base-classes": "^1.3.0",
+    "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.1",
-    "@tvkitchen/base-interfaces": "^3.0.0"
-  },
-  "devDependencies": {
-    "@tvkitchen/base-constants": "^1.2.0"
+    "@tvkitchen/base-interfaces": "4.0.0-alpha.2",
+    "command-exists": "^1.2.9",
+    "ts-demuxer": "^1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -1,0 +1,193 @@
+import { spawn } from 'child_process'
+import {
+	pipeline,
+	Writable,
+	Transform,
+} from 'stream'
+import commandExists from 'command-exists'
+import { Payload } from '@tvkitchen/base-classes'
+import {
+	dataTypes,
+	applianceEvents,
+} from '@tvkitchen/base-constants'
+import {
+	AbstractInstantiationError,
+	NotImplementedError,
+} from '@tvkitchen/base-errors'
+import { TSDemuxer } from 'ts-demuxer'
+import AbstractAppliance from './AbstractAppliance'
+import {
+	tsToMilliseconds,
+	generateEmptyPacket,
+} from './utils/mpegts'
+
+/**
+ * An AbstractVideoIngestionAppliance provides generic functionality for converting an arbitrary
+ * video input stream into VIDEO.CONTAINER payloads.
+ *
+ * We decided to make this a core abstract class that other appliances could extend because
+ * ingesting video from different types of source in a normalized way is a core aspect of TV
+ * Kitchen functionality.
+ */
+class AbstractVideoIngestionAppliance extends AbstractAppliance {
+	// The FFmpeg process used to wrap the ingestion stream in an MPEG-TS container
+	ffmpegProcess = null
+
+	// The ingestion stream consumed by this engine, started by `start()` and stopped by `stop()`
+	activeInputStream = null
+
+	// Utility for processing the MPEG-TS stream produced by ffmpeg
+	mpegtsDemuxer = null
+
+	// A shim variable that allows us to use the output of TSDemuxer in our engine
+	mostRecentDemuxedPacket = null
+
+	// A Transformation stream that will convert MPEG-TS data into TV Kitchen Payloads
+	mpegtsProcessingStream = null
+
+	// A Writeable stream that will ingest Payloads into the TV Kitchen pipeline.
+	payloadIngestionStream = null
+
+	constructor(overrideSettings = {}) {
+		super(overrideSettings)
+		if (this.constructor === AbstractVideoIngestionAppliance) {
+			throw new AbstractInstantiationError(this.constructor.name)
+		}
+
+		this.mpegtsDemuxer = new TSDemuxer(this.onDemuxedPacket)
+
+		this.mpegtsProcessingStream = Transform({
+			objectMode: true,
+			transform: this.processMpegtsStreamData,
+		})
+
+		this.payloadIngestionStream = Writable({
+			objectMode: true,
+			write: (payload) => this.emit(applianceEvents.PAYLOAD, payload),
+		})
+	}
+
+	/**
+	 * Returns an FFmpeg settings array for this ingestion engine.
+	 *
+	 * @return {String[]} A list of FFmpeg command line parameters
+	 */
+	getFfmpegSettings = () => [
+		'-loglevel', 'info',
+		'-i', '-',
+		'-codec', 'copy',
+		'-f', 'mpegts',
+		'-',
+	]
+
+	/**
+	 * The ReadableStream that is being ingested by the ingestion engine.
+	 *
+	 * NOTE: THIS MUST BE IMPLEMENTED
+	 *
+	 * @return {ReadableStream} The stream of data to be ingested by the ingestion engine
+	 */
+	getInputStream = () => {
+		throw new NotImplementedError('getInputStream')
+	}
+
+	/**
+	 * Updates ingestion state based on the latest demuxed packet data.
+	 *
+	 * This method is called by our MPEG-TS demuxer, and allows the ingestion engine to track
+	 * the most recent demuxed packet.
+	 *
+	 * @param  {Packet} packet The latest TSDemuxer Packet object
+	 */
+	onDemuxedPacket = (packet) => {
+		this.mostRecentDemuxedPacket = packet
+	}
+
+	/**
+	 * Returns the most recent coherent stream packet processed by the ingestion engine.
+	 * This packet is lower level than the MPEG-TS container, and represents an audio or video
+	 * packet demuxed from the MPEG-TS stream.
+	 *
+	 * @return {Packet} The most recent Packet object extracted by TSDemuxer
+	 */
+	getMostRecentDemuxedPacket = () => this.mostRecentDemuxedPacket
+
+	/**
+	 * Process a new chunk of data from an MPEG-TS stream. The chunks passed to this
+	 * function should be presented sequentially, and combine to form a coherent MPEG-TS
+	 * data stream, but they can be of arbitrary size.
+	 *
+	 * This method is called by a NodeJS Transform stream and so matches that spec.
+	 *
+	 * @param  {Buffer} mpegtsData The latest sequential chunk of MPEG-TS data
+	 * @param  {String} enc        The encoding of the passed data
+	 * @param  {Function(err,result)} done     A `(err, result) => ...` callback
+	 *
+	 */
+	processMpegtsStreamData = (mpegtsData, enc, done) => {
+		this.mpegtsDemuxer.process(mpegtsData)
+		const demuxedPacket = this.getMostRecentDemuxedPacket() || generateEmptyPacket()
+		const payload = new Payload({
+			data: mpegtsData,
+			type: dataTypes.STREAM.CONTAINER,
+			duration: 0,
+			position: tsToMilliseconds(demuxedPacket.pts),
+			createdAt: (new Date()).toISOString(),
+		})
+		done(null, payload)
+	}
+
+	/** @inheritdoc */
+	isValidPayload = async () => true
+
+	/** @inheritdoc */
+	audit = async () => {
+		let passed = true
+		if (!commandExists.sync('ffmpeg')) {
+			passed = false
+			this.logger.error('FFmpeg must be installed and the `ffmpeg` command must work.')
+		}
+		return passed
+	}
+
+	/** @inheritdoc */
+	start = async () => {
+		this.ffmpegProcess = spawn('ffmpeg', this.getFfmpegSettings())
+		await this.producer.connect()
+		this.activeInputStream = this.getInputStream()
+
+		this.logger.info(`Starting ingestion from ${this.constructor.name}...`)
+		this.activeInputStream.pipe(this.ffmpegProcess.stdin)
+		return pipeline(
+			this.ffmpegProcess.stdout,
+			this.mpegtsProcessingStream,
+			this.payloadIngestionStream,
+			() => this.stop(),
+		)
+	}
+
+	/** @inheritdoc */
+	stop = async () => {
+		if (this.activeInputStream !== null) {
+			this.activeInputStream.destroy()
+		}
+		if (this.ffmpegProcess !== null) {
+			this.ffmpegProcess.kill()
+		}
+		this.producer.disconnect()
+		this.logger.info(`Ended ingestion from ${this.constructor.name}...`)
+	}
+
+	/** @inheritdoc */
+	invoke = async () => {
+		throw new Error('Ingestion Appliances cannot be invoked.')
+	}
+
+	/** @inheritdoc */
+	static getInputTypes = () => []
+
+	/** @inheritdoc */
+	static getOutputTypes = () => [dataTypes.STREAM.CONTAINER]
+}
+
+export default AbstractVideoIngestionAppliance

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -1,0 +1,204 @@
+// Mocked imports
+import childProcess from 'child_process'
+import stream from 'stream'
+
+// Test imports
+import fs from 'fs'
+import path from 'path'
+import {
+	AbstractInstantiationError,
+	NotImplementedError,
+} from '@tvkitchen/base-errors'
+import { dataTypes } from '@tvkitchen/base-constants'
+import { Payload } from '@tvkitchen/base-classes'
+import AbstractVideoIngestionAppliance from '../AbstractVideoIngestionAppliance'
+import FullyImplementedVideoIngestionAppliance from './classes/FullyImplementedVideoIngestionAppliance'
+import PartiallyImplementedVideoIngestionAppliance from './classes/PartiallyImplementedVideoIngestionAppliance'
+
+// Set up mocks
+jest.mock('child_process')
+jest.mock('stream')
+
+// A helper for loading data
+const loadTestData = (testDirectory, fileName) => JSON.parse(fs.readFileSync(
+	path.join(testDirectory, 'data', fileName),
+))
+
+// This pulls actual versions of mocked components, since we use them
+const {
+	Readable,
+	Writable,
+} = jest.requireActual('stream')
+
+describe('AbstractVideoIngestionAppliance #unit', () => {
+	describe('constructor', () => {
+		it('should throw an error when called directly', () => {
+			expect(() => new AbstractVideoIngestionAppliance())
+				.toThrow(AbstractInstantiationError)
+		})
+
+		it('should allow construction when extended', () => {
+			expect(() => new PartiallyImplementedVideoIngestionAppliance())
+				.not.toThrow(Error)
+		})
+	})
+
+	describe('processMpegtsStreamData', () => {
+		it('should pass the data to the mpegts demuxer', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.mpegtsDemuxer = {
+				process: jest.fn(),
+			}
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({ pts: 0 })
+			const streamData = Buffer.from('testDataXYZ', 'utf8')
+			ingestionAppliance.processMpegtsStreamData(streamData, null, () => {
+				expect(ingestionAppliance.mpegtsDemuxer.process).toHaveBeenCalledTimes(1)
+			})
+		})
+		it('should emit a Payload of type STREAM.CONTAINER', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.mpegtsDemuxer = { process: jest.fn }
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({ pts: 0 })
+			const streamData = Buffer.from('testDataXYZ', 'utf8')
+			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
+				expect(result).toBeInstanceOf(Payload)
+				expect(result.type).toEqual(dataTypes.STREAM.CONTAINER)
+			})
+		})
+		it('should emit a Payload that contains the MPEG-TS data', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.mpegtsDemuxer = { process: jest.fn }
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({ pts: 0 })
+			const streamData = Buffer.from('testDataXYZ', 'utf8')
+			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
+				expect(result).toBeInstanceOf(Payload)
+				expect(result.data).toEqual(streamData)
+			})
+		})
+		it('should correctly decorate the Payload with time', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.mpegtsDemuxer = {
+				process: jest.fn(),
+			}
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({
+				pts: 90000,
+			})
+			const streamData = Buffer.from('testDataXYZ', 'utf8')
+			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
+				expect(result.position).toEqual(1000)
+				expect(typeof result.createdAt).toBe('string')
+			})
+		})
+	})
+
+	describe('onDemuxedPacket', () => {
+		it('should register new packets as most recent', () => {
+			const testData = loadTestData(__dirname, 'onDemuxedPacket.json')
+			const demuxedPacket = testData[0]
+			const demuxedPacket2 = testData[1]
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.onDemuxedPacket(demuxedPacket)
+			ingestionAppliance.onDemuxedPacket(demuxedPacket2)
+			expect(ingestionAppliance.mostRecentDemuxedPacket).toEqual(demuxedPacket2)
+		})
+	})
+
+	describe('getMostRecentDemuxedPacket', () => {
+		it('should return the value in most recent demuxed packet', () => {
+			const testData = loadTestData(__dirname, 'getMostRecentDemuxedPacket.json')
+			const demuxedPacket = testData[0]
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.mostRecentDemuxedPacket = demuxedPacket
+			expect(ingestionAppliance.getMostRecentDemuxedPacket()).toEqual(demuxedPacket)
+		})
+		it('should return null if nothing has been processed', () => {
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			expect(ingestionAppliance.getMostRecentDemuxedPacket()).toBe(null)
+		})
+	})
+
+	describe('start', () => {
+		it('should spawn an ffmpeg process', () => {
+			jest.clearAllMocks()
+			childProcess.spawn.mockReturnValueOnce({
+				stdout: new Readable(),
+				stdin: new Writable(),
+			})
+			const inputStream = new Readable({ read: () => {} })
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance(inputStream)
+			ingestionAppliance.producer = { connect: jest.fn().mockResolvedValue() }
+			ingestionAppliance.start()
+			expect(childProcess.spawn).toHaveBeenCalledTimes(1)
+		})
+		it('should create a processing pipeline', async () => {
+			jest.clearAllMocks()
+			childProcess.spawn.mockReturnValueOnce({
+				stdout: new Readable(),
+				stdin: new Writable(),
+			})
+			childProcess.spawn.mockReturnValueOnce({})
+			const inputStream = new Readable({ read: jest.fn() })
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance(inputStream)
+			ingestionAppliance.producer = { connect: jest.fn().mockResolvedValue() }
+			await ingestionAppliance.start()
+			expect(stream.pipeline).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('stop', () => {
+		it('should kill the ffmpeg process and stop the stream', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.activeInputStream = {
+				destroy: jest.fn(),
+			}
+			ingestionAppliance.ffmpegProcess = {
+				kill: jest.fn(),
+			}
+			ingestionAppliance.producer = {
+				disconnect: jest.fn(),
+			}
+			ingestionAppliance.stop()
+			expect(ingestionAppliance.activeInputStream.destroy).toHaveBeenCalledTimes(1)
+			expect(ingestionAppliance.ffmpegProcess.kill).toHaveBeenCalledTimes(1)
+		})
+		it('should not error if called before starting', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.producer = {
+				disconnect: jest.fn(),
+			}
+			expect(() => ingestionAppliance.stop()).not.toThrow()
+		})
+	})
+
+	describe('getFfmpegSettings', () => {
+		it('should return an array', () => {
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			expect(ingestionAppliance.getFfmpegSettings()).toBeInstanceOf(Array)
+		})
+	})
+
+	describe('getInputStream', () => {
+		it('should throw an error when called without an implementation', () => {
+			const ingestionAppliance = new PartiallyImplementedVideoIngestionAppliance()
+			expect(ingestionAppliance.getInputStream).toThrow(NotImplementedError)
+		})
+	})
+
+	describe('getInputTypes', () => {
+		it('should return an empty array', () => {
+			expect(AbstractVideoIngestionAppliance.getInputTypes()).toEqual([])
+		})
+	})
+
+	describe('getOutputTypes', () => {
+		it('should return a the STREAM.CONTAINER', () => {
+			expect(AbstractVideoIngestionAppliance.getOutputTypes()).toEqual([dataTypes.STREAM.CONTAINER])
+		})
+	})
+})

--- a/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
@@ -1,0 +1,12 @@
+import AbstractVideoIngestionAppliance from '../../AbstractVideoIngestionAppliance'
+
+class FullyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppliance {
+	constructor(readableStream) {
+		super()
+		this.readableStream = readableStream
+	}
+
+	getInputStream = () => this.readableStream
+}
+
+export default FullyImplementedVideoIngestionAppliance

--- a/packages/core/src/__test__/classes/PartiallyImplementedVideoIngestionAppliance.js
+++ b/packages/core/src/__test__/classes/PartiallyImplementedVideoIngestionAppliance.js
@@ -1,0 +1,5 @@
+import AbstractVideoIngestionAppliance from '../../AbstractVideoIngestionAppliance'
+
+class PartiallyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppliance { }
+
+export default PartiallyImplementedVideoIngestionAppliance

--- a/packages/core/src/__test__/classes/index.js
+++ b/packages/core/src/__test__/classes/index.js
@@ -1,2 +1,8 @@
 export { default as FullyImplementedAppliance } from './FullyImplementedAppliance'
 export { default as PartiallyImplementedAppliance } from './PartiallyImplementedAppliance'
+export {
+	default as FullyImplementedVideoIngestionAppliance,
+} from './FullyImplementedVideoIngestionAppliance'
+export {
+	default as PartiallyImplementedIngestionAppliance,
+} from './PartiallyImplementedVideoIngestionAppliance'

--- a/packages/core/src/__test__/data/getMostRecentDemuxedPacket.json
+++ b/packages/core/src/__test__/data/getMostRecentDemuxedPacket.json
@@ -1,0 +1,30 @@
+[
+  {
+    "data": [
+      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
+    ],
+    "pts": 1255128,
+    "dts": 1252125,
+    "frame_ticks": 3003,
+    "program": 1,
+    "stream_number": 1,
+    "stream_id": 224,
+    "type": 1,
+    "content_type": 2,
+    "frame_num": 377
+  },
+  {
+    "data": [
+      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
+    ],
+    "pts": 1255128,
+    "dts": 1252125,
+    "frame_ticks": 3003,
+    "program": 1,
+    "stream_number": 1,
+    "stream_id": 224,
+    "type": 1,
+    "content_type": 2,
+    "frame_num": 378
+  }
+]

--- a/packages/core/src/__test__/data/onDemuxedPacket.json
+++ b/packages/core/src/__test__/data/onDemuxedPacket.json
@@ -1,0 +1,16 @@
+[
+  {
+    "data": [
+      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
+    ],
+    "pts": 1255128,
+    "dts": 1252125,
+    "frame_ticks": 3003,
+    "program": 1,
+    "stream_number": 1,
+    "stream_id": 224,
+    "type": 1,
+    "content_type": 2,
+    "frame_num": 377
+  }
+]

--- a/packages/core/src/constants/events.js
+++ b/packages/core/src/constants/events.js
@@ -1,3 +1,0 @@
-export const OUTPUT = 'OUTPUT'
-
-export const INPUT_RECEIVED = 'INPUT_RECEIVED'

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,2 +1,2 @@
-/* eslint-disable import/prefer-default-export */
 export { default as AbstractAppliance } from './AbstractAppliance'
+export { default as AbstractVideoIngestionAppliance } from './AbstractVideoIngestionAppliance'

--- a/packages/core/src/utils/__test__/mpegts.test.js
+++ b/packages/core/src/utils/__test__/mpegts.test.js
@@ -1,0 +1,33 @@
+import {
+	tsToMilliseconds,
+	generateEmptyPacket,
+} from '../mpegts'
+
+describe('mpegts utilities', () => {
+	describe('tsToMilliseconds()', () => {
+		it('should convert successfuly with the default basetime', () => {
+			expect(tsToMilliseconds(90000)).toBe(1000)
+		})
+		it('should convert successfuly with an override basetime', () => {
+			expect(tsToMilliseconds(500, 200)).toBe(2500)
+		})
+	})
+
+	describe('generateEmptyPacket', () => {
+		it('should have zeroed-out attributes of a TSDemuxer Packet', () => {
+			const emptyPacket = generateEmptyPacket()
+			expect(emptyPacket).toMatchObject({
+				data: [],
+				pts: 0,
+				dts: 0,
+				frame_ticks: 0,
+				program: 0,
+				stream_number: 0,
+				type: 0,
+				stream_id: 0,
+				content_type: 0,
+				frame_num: 0,
+			})
+		})
+	})
+})

--- a/packages/core/src/utils/mpegts.js
+++ b/packages/core/src/utils/mpegts.js
@@ -1,0 +1,26 @@
+/**
+ * Converts a pts or dts extracted from an MPEG-TS packet to seconds.
+ *
+ * @param  {Number} ts       The pts or dts value to be converted.
+ * @param  {Number} baseTime The MPEG-TS basetime associated with the ts.
+ * @return {Number}          The number of seconds represented by the pts or dts.
+ */
+export const tsToMilliseconds = (ts, baseTime = 90000) => +((ts / baseTime) * 1000).toFixed(0)
+
+/**
+ * Exports a TSDemuxer MPEG-TS Packet as defined in the TSDemuxer project.
+ *
+ * @return {Object} A TSDemuxer Packet with no data
+ */
+export const generateEmptyPacket = () => ({
+	data: [],
+	pts: 0,
+	dts: 0,
+	frame_ticks: 0,
+	program: 0,
+	stream_number: 0,
+	type: 0,
+	stream_id: 0,
+	content_type: 0,
+	frame_num: 0,
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,7 +1033,7 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
   integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
 
-"@tvkitchen/base-constants@^1.1.0", "@tvkitchen/base-constants@^1.2.0":
+"@tvkitchen/base-constants@1.2.0", "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-constants/-/base-constants-1.2.0.tgz#020246bd1ff700e67066eea2e708dc5254cbcb9d"
   integrity sha512-9oyAYcMwWH1NiM9kFJ6yxameRBb58gq3/NCPBcXxVRe8IdHnQ3XKVC0fw0J3pfeOgOHayEeVTtEcSx4FlhilOw==
@@ -1043,12 +1043,12 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-errors/-/base-errors-1.0.1.tgz#1117e17c8a0888989ad155d1318d03b6a6ab942f"
   integrity sha512-AHb+LYbughr1dggUFiAA7y079ZRrjgLiW2KOJgeHbQXSr1kcaxcAnISUV8e1EYuUODhmN1FD8ka9T0d9+RLzKQ==
 
-"@tvkitchen/base-interfaces@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-3.0.0.tgz#1c475f032894675d56df4a8a2f46ed7c6d84bc57"
-  integrity sha512-sKhRYSVc65r/hlGRPgQlQfzIrn3frfUOrozomzZhAm49tbw9hTteg6yYcvaYI+pP/JDtC+i3vkv3/aiEoKccxA==
+"@tvkitchen/base-interfaces@4.0.0-alpha.1":
+  version "4.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.1.tgz#dca15fc07be492a3b726bd9c04e936dad8438e2b"
+  integrity sha512-i0kBOgVn3ASDrFoe++lfiYfxIiSOc5/jhWI+VlXJaxd5MBVtjNI0wltly/2VX8c4hlZ+TKDSpm3c7SmHQ5HoPQ==
   dependencies:
-    "@tvkitchen/base-constants" "^1.1.0"
+    "@tvkitchen/base-constants" "^1.1.1"
     "@tvkitchen/base-errors" "^1.0.0"
 
 "@types/babel__core@^7.1.7":
@@ -1681,6 +1681,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+command-exists@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
 commander@^4.0.1:
   version "4.1.1"
@@ -4911,6 +4916,11 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+ts-demuxer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ts-demuxer/-/ts-demuxer-1.0.0.tgz#b0b873e7951a5a272e671acb82f622256d9eb891"
+  integrity sha512-76K1Tyb82CbawAUJ6Qz76TykS3SdgEWpJtE3GkUdBvOgdc/mkxns/1dDsViUNpmWZkBDWGBtnJl4EsYULc7Ruw==
 
 tslib@^1.9.0:
   version "1.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,7 +1033,7 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
   integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
 
-"@tvkitchen/base-constants@1.2.0", "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
+"@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-constants/-/base-constants-1.2.0.tgz#020246bd1ff700e67066eea2e708dc5254cbcb9d"
   integrity sha512-9oyAYcMwWH1NiM9kFJ6yxameRBb58gq3/NCPBcXxVRe8IdHnQ3XKVC0fw0J3pfeOgOHayEeVTtEcSx4FlhilOw==
@@ -1043,10 +1043,10 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-errors/-/base-errors-1.0.1.tgz#1117e17c8a0888989ad155d1318d03b6a6ab942f"
   integrity sha512-AHb+LYbughr1dggUFiAA7y079ZRrjgLiW2KOJgeHbQXSr1kcaxcAnISUV8e1EYuUODhmN1FD8ka9T0d9+RLzKQ==
 
-"@tvkitchen/base-interfaces@4.0.0-alpha.1":
-  version "4.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.1.tgz#dca15fc07be492a3b726bd9c04e936dad8438e2b"
-  integrity sha512-i0kBOgVn3ASDrFoe++lfiYfxIiSOc5/jhWI+VlXJaxd5MBVtjNI0wltly/2VX8c4hlZ+TKDSpm3c7SmHQ5HoPQ==
+"@tvkitchen/base-interfaces@4.0.0-alpha.2":
+  version "4.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.2.tgz#9eee6837a0a8b33828186bef7564bb1084816e0e"
+  integrity sha512-B+clkl+hHVQNJ5nLgQWC+0Q22g/X0/UqWLRFLDE5sBBx1QzyxJm6Dp3miBvgcU9lJS/aqpsljEuNDY2hHTrzKw==
   dependencies:
     "@tvkitchen/base-constants" "^1.1.1"
     "@tvkitchen/base-errors" "^1.0.0"


### PR DESCRIPTION
## Description
This PR Adds a new `core` class for appliances: `AbstractIngestionAppliance`.

The AbstractIngestionAppliance converts a video stream into properly decorated Payload objects, and emits those objects in the same way any appliance would emit the Payloads it creates.

The bulk of this logic was taken directly from the old "Ingestion Engine" architecture over in the [tv-kitchen](https://github.com/tvkitchen/tv-kitchen) repository.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
This is a new feature (minor)

## Related Issues
Related to #32