### PR TITLE
Add Video File Ingestion Appliance

### DIFF
--- a/packages/file-ingestion/CHANGELOG.md
+++ b/packages/file-ingestion/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for @tvkitchen/appliance-file-ingestion
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+- Initial implementation of the `VideoFileIngestion` appliance.
+
+### Changed

--- a/packages/file-ingestion/README.md
+++ b/packages/file-ingestion/README.md
@@ -1,0 +1,17 @@
+# TV Kitchen Video File Ingestion Appliance
+
+---
+inputTypes: none
+outputTypes: STREAM.CONTAINER
+---
+
+The Video File Ingestion appliance is configured to ingest a video file and conver it into `STREAM.CONTAINER` payloads.
+
+## Dependencies
+
+In order to use this appliance, you must have [ffmpeg](https://www.ffmpeg.org/) installed on your system, and the `ffmpeg` command must work.
+
+## About the TV Kitchen
+
+TV Kitchen is a project of [Bad Idea Factory](https://biffud.com).  Learn more at [the TV Kitchen project site](https://tv.kitchen).
+

--- a/packages/file-ingestion/package.json
+++ b/packages/file-ingestion/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tvkitchen/appliance-video-file-ingestion",
+  "description": "Converts a video file into MPEG-TS Payloads.",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tvkitchen/appliances.git",
+    "directory": "packages/file-ingestion"
+  },
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "dependencies": {
+    "@tvkitchen/appliance-core": "0.2.0",
+    "@tvkitchen/base-constants": "1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/file-ingestion/src/VideoFileIngestionAppliance.js
+++ b/packages/file-ingestion/src/VideoFileIngestionAppliance.js
@@ -1,0 +1,41 @@
+import fs from 'fs'
+import { applianceEvents } from '@tvkitchen/base-constants'
+import { AbstractVideoIngestionAppliance } from '@tvkitchen/appliance-core'
+
+class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
+	filePath = null
+
+	/**
+	* Create a VideoFileIngestionEngine.
+	*
+	* @param  {String} overrideSettings.filePath The path of the file to be ingested.
+	*/
+	constructor(overrideSettings = {
+		filePath: '',
+	}) {
+		super(overrideSettings)
+		if (!overrideSettings.filePath) {
+			throw new Error('VideoFileIngestionAppliances must be instantiated with a configured filePath.')
+		}
+		this.filePath = overrideSettings.filePath
+	}
+
+	/** @inheritdoc */
+	getInputStream = () => fs.createReadStream(this.filePath)
+
+	/** @inheritdoc */
+	start = async () => {
+		this.emit(applianceEvents.STARTING)
+		await super.start()
+		this.emit(applianceEvents.READY)
+	}
+
+	/** @inheritdoc */
+	stop = async () => {
+		this.emit(applianceEvents.STOPPING)
+		await super.stop()
+		this.emit(applianceEvents.STOPPED)
+	}
+}
+
+export default VideoFileIngestionAppliance

--- a/packages/file-ingestion/src/__test__/VideoFileIngestionAppliance.unit.test.js
+++ b/packages/file-ingestion/src/__test__/VideoFileIngestionAppliance.unit.test.js
@@ -1,0 +1,22 @@
+import path from 'path'
+import { ReadStream } from 'fs'
+import VideoFileIngestionAppliance from '../VideoFileIngestionAppliance'
+
+describe('VideoFileIngestionAppliance #unit', () => {
+	describe('constructor', () => {
+		it('should throw an error when called without a path', () => {
+			expect(() => new VideoFileIngestionAppliance())
+				.toThrow(Error)
+		})
+	})
+
+	describe('getInputStream', () => {
+		it('it should return a file read stream', () => {
+			const ingestionAppliance = new VideoFileIngestionAppliance({
+				filePath: path.join(__dirname, '/data/empty.txt'),
+			})
+			const inputStream = ingestionAppliance.getInputStream()
+			expect(inputStream).toBeInstanceOf(ReadStream)
+		})
+	})
+})

--- a/packages/file-ingestion/src/index.js
+++ b/packages/file-ingestion/src/index.js
@@ -1,0 +1,3 @@
+import VideoFileIngestionAppliance from './VideoFileIngestionAppliance'
+
+export default VideoFileIngestionAppliance

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,7 +1033,7 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
   integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
 
-"@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
+"@tvkitchen/base-constants@1.2.0", "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-constants/-/base-constants-1.2.0.tgz#020246bd1ff700e67066eea2e708dc5254cbcb9d"
   integrity sha512-9oyAYcMwWH1NiM9kFJ6yxameRBb58gq3/NCPBcXxVRe8IdHnQ3XKVC0fw0J3pfeOgOHayEeVTtEcSx4FlhilOw==


### PR DESCRIPTION
## Description
This PR adds a `video-file-ingestion` appliance, which is ported from its equivalent `FileIngestionEngine` in the tv-kitchen repository by @chriszs 

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
This creates a new package.

## Related Issues
Related to #32 
Relies on #34 
