### PR TITLE
Add HTTP Ingestion Appliance

### DIFF
--- a/packages/video-http-ingestion/README.md
+++ b/packages/video-http-ingestion/README.md
@@ -1,0 +1,17 @@
+# TV Kitchen Video HTTP Ingestion Appliance
+
+---
+inputTypes: none
+outputTypes: STREAM.CONTAINER
+---
+
+The Video HTTP Ingestion appliance is configured to ingest a video URL and convert it into `STREAM.CONTAINER` payloads.
+
+## Dependencies
+
+In order to use this appliance, you must have [ffmpeg](https://www.ffmpeg.org/) installed on your system, and the `ffmpeg` command must work.
+
+## About the TV Kitchen
+
+TV Kitchen is a project of [Bad Idea Factory](https://biffud.com).  Learn more at [the TV Kitchen project site](https://tv.kitchen).
+

--- a/packages/video-http-ingestion/package.json
+++ b/packages/video-http-ingestion/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tvkitchen/appliance-http-ingestion",
+  "description": "Converts a video url into MPEG-TS Payloads.",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tvkitchen/appliances.git",
+    "directory": "packages/video-http-ingestion"
+  },
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "dependencies": {
+    "@tvkitchen/appliance-core": "0.2.0",
+    "node-fetch": "^2.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "nock": "^13.0.4"
+  }
+}

--- a/packages/video-http-ingestion/src/VideoHttpIngestionAppliance.js
+++ b/packages/video-http-ingestion/src/VideoHttpIngestionAppliance.js
@@ -1,0 +1,47 @@
+import { PassThrough } from 'stream'
+import fetch from 'node-fetch'
+import { AbstractVideoIngestionAppliance } from '@tvkitchen/appliance-core'
+
+/**
+ * The VideoHttpIngestionAppliance handles processing a HTTP video stream. It is a concrete
+ * implementation of AbstractIngestionAppliance, which reads in a stream, converts it into
+ * an MPEG-TS stream represented as a series of Payloads, and then emits those Payloads.
+ *
+ * @extends AbstractVideoIngestionAppliance
+ */
+class VideoHttpIngestionAppliance extends AbstractVideoIngestionAppliance {
+	/**
+	 * Create a VideoHttpIngestionEngine.
+	 *
+	 * @param  {string} settings.url The url of the stream to be ingested
+	 */
+	constructor(settings = {
+		url: '',
+	}) {
+		super(settings)
+		if (!settings.url) {
+			throw new Error(
+				'HttpIngestionAppliance must be instantiated with a stream URL',
+			)
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	getInputStream = () => {
+		const stream = new PassThrough()
+
+		fetch(this.settings.url)
+			.then((response) => {
+				response.body.pipe(stream)
+			})
+			.catch((err) => {
+				stream.emit('error', err)
+			})
+
+		return stream
+	}
+}
+
+export default VideoHttpIngestionAppliance

--- a/packages/video-http-ingestion/src/__test__/VideoHttpIngestionEngine.unit.test.js
+++ b/packages/video-http-ingestion/src/__test__/VideoHttpIngestionEngine.unit.test.js
@@ -1,0 +1,51 @@
+import nock from 'nock'
+import VideoHttpIngestionAppliance from '../VideoHttpIngestionAppliance'
+
+describe('VideoHttpIngestionAppliance #unit', () => {
+	describe('constructor', () => {
+		it('should throw an error when called without a URL', () => {
+			expect(() => new VideoHttpIngestionAppliance())
+				.toThrow(Error)
+		})
+	})
+
+	describe('getInputStream', () => {
+		it('it should stream the client request body', () => {
+			const base = 'http://example.com'
+			const file = '/test.ts'
+			const body = 'it worked!'
+
+			nock(base).get(file).reply(200, body)
+
+			const ingestionAppliance = new VideoHttpIngestionAppliance({
+				url: `${base}${file}`,
+			})
+
+			const inputStream = ingestionAppliance.getInputStream()
+
+			return expect(
+				new Promise((resolve) => inputStream.on('data', resolve)),
+			).resolves.toEqual(Buffer.from(body))
+		})
+
+		it('it should pass on errors correctly', () => {
+			const base = 'http://example.com'
+			const file = '/error-test.ts'
+			const message = 'it didn\'t work!'
+
+			nock(base).get(file).replyWithError({
+				message,
+			})
+
+			const ingestionAppliance = new VideoHttpIngestionAppliance({
+				url: `${base}${file}`,
+			})
+
+			const inputStream = ingestionAppliance.getInputStream()
+
+			return expect(
+				new Promise((resolve, reject) => inputStream.on('error', reject)),
+			).rejects.toHaveProperty('name', 'FetchError')
+		})
+	})
+})

--- a/packages/video-http-ingestion/src/index.js
+++ b/packages/video-http-ingestion/src/index.js
@@ -1,0 +1,3 @@
+import VideoHttpIngestionAppliance from './VideoHttpIngestionAppliance'
+
+export default VideoHttpIngestionAppliance

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,7 +3383,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -3491,6 +3491,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -3673,6 +3678,16 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nock@^13.0.4:
+  version "13.0.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.4.tgz#9fb74db35d0aa056322e3c45be14b99105cd7510"
+  integrity sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
+
 node-environment-flags@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
@@ -3680,6 +3695,11 @@ node-environment-flags@^1.0.5:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4098,6 +4118,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 psl@^1.1.28:
   version "1.8.0"


### PR DESCRIPTION
## Description
This PR adds an appliance that can convert a video URL into STREAM.CONTAINER payloads.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
This is the final ingestion engine to be converted, so it resolves #32 
Relies on #36 