### PR TITLE
Rename override settings

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Rename `overrideSettings` to `settings` in abstract appliance classes.
 
 ## [0.2.0] - 2020-08-25
 ### Added

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -25,14 +25,14 @@ class AbstractAppliance extends IAppliance {
 
 	payloads = new PayloadArray()
 
-	constructor(overrideSettings = {}) {
+	constructor(settings = {}) {
 		super()
 		if (this.constructor === AbstractAppliance) {
 			throw new AbstractInstantiationError('AbstractAppliance')
 		}
 		Object.assign(
 			this.settings,
-			overrideSettings,
+			settings,
 		)
 	}
 

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -48,8 +48,8 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	// A Writeable stream that will ingest Payloads into the TV Kitchen pipeline.
 	payloadIngestionStream = null
 
-	constructor(overrideSettings = {}) {
-		super(overrideSettings)
+	constructor(settings = {}) {
+		super(settings)
 		if (this.constructor === AbstractVideoIngestionAppliance) {
 			throw new AbstractInstantiationError(this.constructor.name)
 		}

--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Corrected the path to be `packages/video-file-ingestion`.
+- Renamed `overrideSettings` to `settings`.

--- a/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
+++ b/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
@@ -8,16 +8,16 @@ class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
 	/**
 	* Create a VideoFileIngestionEngine.
 	*
-	* @param  {String} overrideSettings.filePath The path of the file to be ingested.
+	* @param  {String} settings.filePath The path of the file to be ingested.
 	*/
-	constructor(overrideSettings = {
+	constructor(settings = {
 		filePath: '',
 	}) {
-		super(overrideSettings)
-		if (!overrideSettings.filePath) {
+		super(settings)
+		if (!settings.filePath) {
 			throw new Error('VideoFileIngestionAppliances must be instantiated with a configured filePath.')
 		}
-		this.filePath = overrideSettings.filePath
+		this.filePath = settings.filePath
 	}
 
 	/** @inheritdoc */


### PR DESCRIPTION
## Description
This PR changes the `overrideSettings` constructor parameter to `settings` in a few places.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- This is a patch level change for all affected packages.

## Related Issues
Resolves #39 