### PR TITLE
Add isValidPayload to AbstractAppliance

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rename `overrideSettings` to `settings` in abstract appliance classes.
 
+### Added
+- `isValidPayload` implementation to `AbstractAppliance`.
+
 ## [0.2.0] - 2020-08-25
 ### Added
 - Initial implementation of the `AbstractVideoIngestionAppliance`.

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -36,6 +36,16 @@ class AbstractAppliance extends IAppliance {
 		)
 	}
 
+	/** @inheritdoc */
+	isValidPayload = async (payload) => {
+		assert(
+			this.constructor.getInputTypes().includes(payload.type),
+			`${payload.type} is not a valid Payload type for this appliance.`,
+		)
+		return true
+	}
+
+	/** @inheritdoc */
 	ingestPayload = async (payload) => {
 		assert(
 			Payload.isPayload(payload),
@@ -56,6 +66,7 @@ class AbstractAppliance extends IAppliance {
 		return werePayloadsProcessed
 	}
 
+	/** @inheritdoc */
 	on = (eventType, listener) => this.emitter.on(eventType, listener)
 
   /**

--- a/packages/core/src/__test__/AbstractAppliance.test.js
+++ b/packages/core/src/__test__/AbstractAppliance.test.js
@@ -11,6 +11,8 @@ import {
 	PartiallyImplementedAppliance,
 } from './classes'
 
+const getValidPayload = () => new Payload({ type: 'FOO' })
+
 describe('AbstractAppliance #unit', () => {
 	describe('construction', () => {
 		it('should throw an error when constructed directly', () => {
@@ -26,6 +28,21 @@ describe('AbstractAppliance #unit', () => {
 		})
 	})
 
+	describe('isValidPayload', () => {
+		it('should error when passed a payload with an invalid type', async () => {
+			expect.assertions(1)
+			const payload = new Payload({ type: 'not a real payload type' })
+			const appliance = new FullyImplementedAppliance()
+			appliance.isValidPayload(payload)
+				.catch((err) => expect(err).toBeDefined())
+		})
+		it('should return true when passed a payload with a matching inputType', async () => {
+			const payload = new Payload({ type: 'FOO' })
+			const appliance = new FullyImplementedAppliance()
+			expect(await appliance.isValidPayload(payload)).toBe(true)
+		})
+	})
+
 	describe('ingestPayload', () => {
 		it('should throw an error when a non-payload is ingested', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
@@ -38,9 +55,9 @@ describe('AbstractAppliance #unit', () => {
 
 		it('should throw an error when an invalid payload is ingested', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
-			implementedAppliance.isValidPayload = () => false
+			implementedAppliance.isValidPayload = async () => false
 			const invokeSpy = jest.spyOn(implementedAppliance, 'invoke')
-			const payload = new Payload()
+			const payload = getValidPayload()
 			await expect(async () => implementedAppliance.ingestPayload(payload))
 				.rejects.toBeInstanceOf(AssertionError)
 			expect(invokeSpy).not.toHaveBeenCalled()
@@ -49,7 +66,7 @@ describe('AbstractAppliance #unit', () => {
 		it('should call invoke() when a valid payload is ingested', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
 			const invokeSpy = jest.spyOn(implementedAppliance, 'invoke')
-			const payload = new Payload()
+			const payload = getValidPayload()
 			await implementedAppliance.ingestPayload(payload)
 			expect(invokeSpy).toHaveBeenCalledTimes(1)
 		})
@@ -57,7 +74,7 @@ describe('AbstractAppliance #unit', () => {
 		it('should pass invoke the list of ingested payloads', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
 			const invokeSpy = jest.spyOn(implementedAppliance, 'invoke')
-			const payload = new Payload()
+			const payload = getValidPayload()
 			await implementedAppliance.ingestPayload(payload)
 			expect(invokeSpy.mock.calls[0][0] instanceof PayloadArray).toBe(true)
 			expect(invokeSpy.mock.calls[0][0].length).toBe(1)
@@ -65,7 +82,7 @@ describe('AbstractAppliance #unit', () => {
 
 		it('should update payloads to be the return value of invoke()', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
-			const payload = new Payload()
+			const payload = getValidPayload()
 			const remainingPayloads = new PayloadArray()
 			implementedAppliance.invoke = jest.fn().mockReturnValueOnce(remainingPayloads)
 			await implementedAppliance.ingestPayload(payload)
@@ -74,7 +91,7 @@ describe('AbstractAppliance #unit', () => {
 
 		it('should return true if invoke returns an empty payload array', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
-			const payload = new Payload()
+			const payload = getValidPayload()
 			const remainingPayloads = new PayloadArray()
 			implementedAppliance.invoke = jest.fn().mockReturnValueOnce(remainingPayloads)
 			expect(await implementedAppliance.ingestPayload(payload)).toBe(true)
@@ -82,9 +99,9 @@ describe('AbstractAppliance #unit', () => {
 
 		it('should return false if invoke returns a payload array of the same size', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
-			const payload = new Payload()
+			const payload = getValidPayload()
 			const remainingPayloads = new PayloadArray(
-				new Payload(),
+				getValidPayload(),
 			)
 			implementedAppliance.invoke = jest.fn().mockReturnValueOnce(remainingPayloads)
 			expect(await implementedAppliance.ingestPayload(payload)).toBe(false)
@@ -100,7 +117,7 @@ describe('AbstractAppliance #unit', () => {
 		})
 		it('should emit an event with specified args', () => {
 			const implementedAppliance = new FullyImplementedAppliance()
-			const payload = new Payload()
+			const payload = getValidPayload()
 			const emitSpy = jest.spyOn(implementedAppliance.emitter, 'emit')
 			implementedAppliance.emit(applianceEvents.PAYLOAD, payload)
 			expect(emitSpy).toBeCalledWith(applianceEvents.PAYLOAD, payload)

--- a/packages/core/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedAppliance.js
@@ -1,11 +1,9 @@
 import AbstractAppliance from '../../AbstractAppliance'
 
 class FullyImplementedAppliance extends AbstractAppliance {
-	getInputTypes = () => []
+	static getInputTypes = () => ['FOO']
 
-	getOutputTypes = () => []
-
-	isValidPayload = async () => true
+	static getOutputTypes = () => ['BAR']
 
 	invoke = async (payloads) => payloads
 }


### PR DESCRIPTION


Issue #41

## Description
This PR adds an `isValidPayload` method to `AbstractAppliance` which ensures that the payload is a valid type for the appliance.

It uses an assertion here (thus triggering an error) because submitting a payload of an invalid type for validation is likely a signal of a more serious problem.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #41 