### PR TITLE
Remove local storage of filePath

### DIFF
--- a/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
+++ b/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
@@ -3,8 +3,6 @@ import { applianceEvents } from '@tvkitchen/base-constants'
 import { AbstractVideoIngestionAppliance } from '@tvkitchen/appliance-core'
 
 class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
-	filePath = null
-
 	/**
 	* Create a VideoFileIngestionEngine.
 	*
@@ -17,11 +15,10 @@ class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
 		if (!settings.filePath) {
 			throw new Error('VideoFileIngestionAppliances must be instantiated with a configured filePath.')
 		}
-		this.filePath = settings.filePath
 	}
 
 	/** @inheritdoc */
-	getInputStream = () => fs.createReadStream(this.filePath)
+	getInputStream = () => fs.createReadStream(this.settings.filePath)
 
 	/** @inheritdoc */
 	start = async () => {


### PR DESCRIPTION
## Description
This PR removes the explicit storage of `filePath` in the `VideoFileIngestionAppliance`.  That data is already stored in the `settings` instance variable.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #43
