### PR TITLE
Remove start from implemented ingestion appliance

### DIFF
--- a/packages/video-file-ingestion/package.json
+++ b/packages/video-file-ingestion/package.json
@@ -11,8 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.2.0",
-    "@tvkitchen/base-constants": "1.2.0"
+    "@tvkitchen/appliance-core": "0.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
+++ b/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import { applianceEvents } from '@tvkitchen/base-constants'
 import { AbstractVideoIngestionAppliance } from '@tvkitchen/appliance-core'
 
 class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
@@ -19,20 +18,6 @@ class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
 
 	/** @inheritdoc */
 	getInputStream = () => fs.createReadStream(this.settings.filePath)
-
-	/** @inheritdoc */
-	start = async () => {
-		this.emit(applianceEvents.STARTING)
-		await super.start()
-		this.emit(applianceEvents.READY)
-	}
-
-	/** @inheritdoc */
-	stop = async () => {
-		this.emit(applianceEvents.STOPPING)
-		await super.stop()
-		this.emit(applianceEvents.STOPPED)
-	}
 }
 
 export default VideoFileIngestionAppliance


### PR DESCRIPTION
## Description
This PR fixes the `VideoFileIngestionAppliance` by removing `start` and `stop` methods and instead relying on the `AbstractVideoIngestionAppliance` implementation (which is kind of the whole point of that class).

It also adds event emissions to the `AbstractVideoIngestionAppliance`

## Due Diligence Checklist
- [x] Tests (removed untested code)
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
Resolves #45 