### PR TITLE
Add payload type to ccextractor

### DIFF
--- a/packages/ccextractor/src/utils/ccextractor.js
+++ b/packages/ccextractor/src/utils/ccextractor.js
@@ -1,4 +1,5 @@
 import { Payload } from '@tvkitchen/base-classes'
+import { dataTypes } from '@tvkitchen/base-constants'
 import CCExtractorLine from '../CCExtractorLine'
 import { getDiff } from './string'
 
@@ -82,6 +83,7 @@ export const convertCcExtractorLineToPayload = (line, previousLine = null) => {
 	const { end } = line
 	return new Payload({
 		data: newCharacters,
+		type: dataTypes.TEXT.ATOM,
 		position: start,
 		duration: end - start,
 	})


### PR DESCRIPTION
## Description
This PR fixes the payloads that the ccextractor appliance emits, by adding the correct `TEXT.ATOM` payload type.

## Due Diligence Checklist
- [x] Tests -- we need #31 
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated -- not yet released so, no change log to add beyond what's there.

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #46 

