### PR TITLE
Fix ffmpeg process

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `AbstractVideoIngestionAppliance` ffmpeg spawn updated to ignore `stderr`.
 
 ## [0.3.1]
 ### Fixed

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -76,7 +76,7 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 * @return {String[]} A list of FFmpeg command line parameters
 	 */
 	getFfmpegSettings = () => [
-		'-loglevel', 'info',
+		'-loglevel', 'quiet',
 		'-i', '-',
 		'-codec', 'copy',
 		'-f', 'mpegts',
@@ -156,7 +156,11 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	/** @inheritdoc */
 	start = async () => {
 		this.emit(applianceEvents.STARTING)
-		this.ffmpegProcess = spawn('ffmpeg', this.getFfmpegSettings())
+		this.ffmpegProcess = spawn(
+			'ffmpeg',
+			this.getFfmpegSettings(),
+			{ stdio: ['pipe', 'pipe', 'ignore'] },
+		)
 		this.activeInputStream = this.getInputStream()
 
 		this.logger.info(`Starting ingestion from ${this.constructor.name}...`)


### PR DESCRIPTION
## Description
This PR fixes the ffmpeg process in AbstractVideoIngestionEngine so that the stderr buffer no longer accumulates over time.

## Steps to Test
To test this, you need a large enough video file (10 minutes of video should be enough), and to create a countertop topology that ingests that video file.  If the ingestion completes, all is well.

## Related Issues
Resolves #53 