### PR TITLE
Always use named exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,12 +4,17 @@
   "rules": {
     "semi": [2, "never"],
     "indent": [2, "tab"],
-    "no-tabs": 0
+    "no-tabs": 0,
+    "import/prefer-default-export": 0,
+    "import/no-default-export":  [2]
   },
   "env": {
     "es6": true,
     "node": true,
     "jest": true
   },
-  "ignorePatterns": ["lib/"]
+  "ignorePatterns": [
+    "lib/",
+    "node_modules"
+  ]
 }

--- a/packages/ccextractor/CHANGELOG.md
+++ b/packages/ccextractor/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed from default exports to named exports.
+
+### Added
+- Now exports the `CCExtractorLine` object because why not.
 
 ## [0.1.0] - 2020-09-09
 ### Added

--- a/packages/ccextractor/src/CCExtractorAppliance.js
+++ b/packages/ccextractor/src/CCExtractorAppliance.js
@@ -13,7 +13,7 @@ import {
 	convertCcExtractorLineToPayload,
 } from './utils/ccextractor'
 
-class CaptionAppliance extends AbstractAppliance {
+class CCExtractorAppliance extends AbstractAppliance {
 	ccExtractorProcess = null
 
 	mostRecentLine = null
@@ -87,4 +87,4 @@ class CaptionAppliance extends AbstractAppliance {
 	}
 }
 
-export default CaptionAppliance
+export { CCExtractorAppliance }

--- a/packages/ccextractor/src/CCExtractorLine.js
+++ b/packages/ccextractor/src/CCExtractorLine.js
@@ -1,4 +1,3 @@
-
 class CCExtractorLine {
 	constructor({
 		start = 0,
@@ -13,4 +12,4 @@ class CCExtractorLine {
 	}
 }
 
-export default CCExtractorLine
+export { CCExtractorLine }

--- a/packages/ccextractor/src/__test__/CCExtraactorLine.unit.test.js
+++ b/packages/ccextractor/src/__test__/CCExtraactorLine.unit.test.js
@@ -1,4 +1,4 @@
-import CCExtractorLine from '../CCExtractorLine'
+import { CCExtractorLine } from '..'
 
 describe('CCExtractorLine', () => {
 	describe('constructor', () => {

--- a/packages/ccextractor/src/__test__/CCExtractorAppliance.unit.test.js
+++ b/packages/ccextractor/src/__test__/CCExtractorAppliance.unit.test.js
@@ -1,6 +1,6 @@
 import { dataTypes } from '@tvkitchen/base-constants'
 import commandExists from 'command-exists'
-import CCExtractorAppliance from '..'
+import { CCExtractorAppliance } from '..'
 
 jest.mock('command-exists')
 

--- a/packages/ccextractor/src/index.js
+++ b/packages/ccextractor/src/index.js
@@ -1,3 +1,2 @@
-import CCExtractorAppliance from './CCExtractorAppliance'
-
-export default CCExtractorAppliance
+export { CCExtractorAppliance } from './CCExtractorAppliance'
+export { CCExtractorLine } from './CCExtractorLine'

--- a/packages/ccextractor/src/utils/__test__/ccextractor.unit.test.js
+++ b/packages/ccextractor/src/utils/__test__/ccextractor.unit.test.js
@@ -5,7 +5,7 @@ import {
 	ccExtractorTimestampToMs,
 	convertCcExtractorLineToPayload,
 } from '../ccextractor'
-import CCExtractorLine from '../../CCExtractorLine'
+import { CCExtractorLine } from '../../CCExtractorLine'
 
 describe('ccextractor utils #unit', () => {
 	describe('parseCcExtractorLine', () => {

--- a/packages/ccextractor/src/utils/ccextractor.js
+++ b/packages/ccextractor/src/utils/ccextractor.js
@@ -1,6 +1,6 @@
 import { Payload } from '@tvkitchen/base-classes'
 import { dataTypes } from '@tvkitchen/base-constants'
-import CCExtractorLine from '../CCExtractorLine'
+import { CCExtractorLine } from '../CCExtractorLine'
 import { getDiff } from './string'
 
 /**

--- a/packages/ccextractor/src/utils/string.js
+++ b/packages/ccextractor/src/utils/string.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 /**
  * Returns the difference between two strings.
  *

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed from default exports to named exports (internally).
+
 ### Fixed
 - `AbstractVideoIngestionAppliance` ffmpeg spawn updated to ignore `stderr`.
 

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -79,4 +79,4 @@ class AbstractAppliance extends IAppliance {
   emit = (event, ...args) => this.emitter.emit(event, ...args)
 }
 
-export default AbstractAppliance
+export { AbstractAppliance }

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -15,7 +15,7 @@ import {
 	NotImplementedError,
 } from '@tvkitchen/base-errors'
 import { TSDemuxer } from 'ts-demuxer'
-import AbstractAppliance from './AbstractAppliance'
+import { AbstractAppliance } from './AbstractAppliance'
 import {
 	tsToMilliseconds,
 	generateEmptyPacket,
@@ -201,4 +201,4 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	static getOutputTypes = () => [dataTypes.STREAM.CONTAINER]
 }
 
-export default AbstractVideoIngestionAppliance
+export { AbstractVideoIngestionAppliance }

--- a/packages/core/src/__test__/AbstractAppliance.test.js
+++ b/packages/core/src/__test__/AbstractAppliance.test.js
@@ -5,7 +5,7 @@ import {
 	PayloadArray,
 } from '@tvkitchen/base-classes'
 import { applianceEvents } from '@tvkitchen/base-constants'
-import AbstractAppliance from '../AbstractAppliance'
+import { AbstractAppliance } from '../AbstractAppliance'
 import {
 	FullyImplementedAppliance,
 	PartiallyImplementedAppliance,

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -11,9 +11,11 @@ import {
 } from '@tvkitchen/base-errors'
 import { dataTypes } from '@tvkitchen/base-constants'
 import { Payload } from '@tvkitchen/base-classes'
-import AbstractVideoIngestionAppliance from '../AbstractVideoIngestionAppliance'
-import FullyImplementedVideoIngestionAppliance from './classes/FullyImplementedVideoIngestionAppliance'
-import PartiallyImplementedVideoIngestionAppliance from './classes/PartiallyImplementedVideoIngestionAppliance'
+import { AbstractVideoIngestionAppliance } from '../AbstractVideoIngestionAppliance'
+import {
+	FullyImplementedVideoIngestionAppliance,
+	PartiallyImplementedVideoIngestionAppliance,
+} from './classes'
 
 // Set up mocks
 jest.mock('child_process')

--- a/packages/core/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedAppliance.js
@@ -1,4 +1,4 @@
-import AbstractAppliance from '../../AbstractAppliance'
+import { AbstractAppliance } from '../../AbstractAppliance'
 
 class FullyImplementedAppliance extends AbstractAppliance {
 	static getInputTypes = () => ['FOO']
@@ -8,4 +8,4 @@ class FullyImplementedAppliance extends AbstractAppliance {
 	invoke = async (payloads) => payloads
 }
 
-export default FullyImplementedAppliance
+export { FullyImplementedAppliance }

--- a/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
@@ -1,4 +1,4 @@
-import AbstractVideoIngestionAppliance from '../../AbstractVideoIngestionAppliance'
+import { AbstractVideoIngestionAppliance } from '../../AbstractVideoIngestionAppliance'
 
 class FullyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppliance {
 	constructor(readableStream) {
@@ -9,4 +9,4 @@ class FullyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppl
 	getInputStream = () => this.readableStream
 }
 
-export default FullyImplementedVideoIngestionAppliance
+export { FullyImplementedVideoIngestionAppliance }

--- a/packages/core/src/__test__/classes/PartiallyImplementedAppliance.js
+++ b/packages/core/src/__test__/classes/PartiallyImplementedAppliance.js
@@ -1,6 +1,6 @@
-import AbstractAppliance from '../../AbstractAppliance'
+import { AbstractAppliance } from '../../AbstractAppliance'
 
 class PartiallyImplementedAppliance extends AbstractAppliance {
 }
 
-export default PartiallyImplementedAppliance
+export { PartiallyImplementedAppliance }

--- a/packages/core/src/__test__/classes/PartiallyImplementedVideoIngestionAppliance.js
+++ b/packages/core/src/__test__/classes/PartiallyImplementedVideoIngestionAppliance.js
@@ -1,5 +1,5 @@
-import AbstractVideoIngestionAppliance from '../../AbstractVideoIngestionAppliance'
+import { AbstractVideoIngestionAppliance } from '../../AbstractVideoIngestionAppliance'
 
 class PartiallyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppliance { }
 
-export default PartiallyImplementedVideoIngestionAppliance
+export { PartiallyImplementedVideoIngestionAppliance }

--- a/packages/core/src/__test__/classes/index.js
+++ b/packages/core/src/__test__/classes/index.js
@@ -1,8 +1,6 @@
-export { default as FullyImplementedAppliance } from './FullyImplementedAppliance'
-export { default as PartiallyImplementedAppliance } from './PartiallyImplementedAppliance'
+export { FullyImplementedAppliance } from './FullyImplementedAppliance'
+export { PartiallyImplementedAppliance } from './PartiallyImplementedAppliance'
+export { FullyImplementedVideoIngestionAppliance } from './FullyImplementedVideoIngestionAppliance'
 export {
-	default as FullyImplementedVideoIngestionAppliance,
-} from './FullyImplementedVideoIngestionAppliance'
-export {
-	default as PartiallyImplementedIngestionAppliance,
+	PartiallyImplementedVideoIngestionAppliance,
 } from './PartiallyImplementedVideoIngestionAppliance'

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,2 +1,2 @@
-export { default as AbstractAppliance } from './AbstractAppliance'
-export { default as AbstractVideoIngestionAppliance } from './AbstractVideoIngestionAppliance'
+export { AbstractAppliance } from './AbstractAppliance'
+export { AbstractVideoIngestionAppliance } from './AbstractVideoIngestionAppliance'

--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed from default exports to named exports.
 
 ## [0.1.1] - 2020-09-10
 ### Changed

--- a/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
+++ b/packages/video-file-ingestion/src/VideoFileIngestionAppliance.js
@@ -20,4 +20,4 @@ class VideoFileIngestionAppliance extends AbstractVideoIngestionAppliance {
 	getInputStream = () => fs.createReadStream(this.settings.filePath)
 }
 
-export default VideoFileIngestionAppliance
+export { VideoFileIngestionAppliance }

--- a/packages/video-file-ingestion/src/__test__/VideoFileIngestionAppliance.unit.test.js
+++ b/packages/video-file-ingestion/src/__test__/VideoFileIngestionAppliance.unit.test.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import { ReadStream } from 'fs'
-import VideoFileIngestionAppliance from '../VideoFileIngestionAppliance'
+import { VideoFileIngestionAppliance } from '../VideoFileIngestionAppliance'
 
 describe('VideoFileIngestionAppliance #unit', () => {
 	describe('constructor', () => {

--- a/packages/video-file-ingestion/src/index.js
+++ b/packages/video-file-ingestion/src/index.js
@@ -1,3 +1,1 @@
-import VideoFileIngestionAppliance from './VideoFileIngestionAppliance'
-
-export default VideoFileIngestionAppliance
+export { VideoFileIngestionAppliance } from './VideoFileIngestionAppliance'

--- a/packages/video-http-ingestion/CHANGELOG.md
+++ b/packages/video-http-ingestion/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed from default exports to named exports.
 
 ## [0.1.1] - 2020-09-16
 ### Changed

--- a/packages/video-http-ingestion/src/VideoHttpIngestionAppliance.js
+++ b/packages/video-http-ingestion/src/VideoHttpIngestionAppliance.js
@@ -44,4 +44,4 @@ class VideoHttpIngestionAppliance extends AbstractVideoIngestionAppliance {
 	}
 }
 
-export default VideoHttpIngestionAppliance
+export { VideoHttpIngestionAppliance }

--- a/packages/video-http-ingestion/src/__test__/VideoHttpIngestionEngine.unit.test.js
+++ b/packages/video-http-ingestion/src/__test__/VideoHttpIngestionEngine.unit.test.js
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import VideoHttpIngestionAppliance from '../VideoHttpIngestionAppliance'
+import { VideoHttpIngestionAppliance } from '../VideoHttpIngestionAppliance'
 
 describe('VideoHttpIngestionAppliance #unit', () => {
 	describe('constructor', () => {

--- a/packages/video-http-ingestion/src/index.js
+++ b/packages/video-http-ingestion/src/index.js
@@ -1,3 +1,1 @@
-import VideoHttpIngestionAppliance from './VideoHttpIngestionAppliance'
-
-export default VideoHttpIngestionAppliance
+export { VideoHttpIngestionAppliance } from './VideoHttpIngestionAppliance'


### PR DESCRIPTION
We never want to use default exports. There are a few reasons for this.
One is that Babel doesn't actually map them to default, which means that
require() doesn't work as expected.

The more important reason is that by using named exports we create
a consistant expectation for how to use appliances and other TVK
components, and also allow appliances to export supporting classes as
necessary.

Issue #55

## Description
This PR changes all instances of default export to use named exports.

## Steps to Test
1. `yarn test`

## Related Issues
Resolves #55
