### PR TITLE
Update appliance core to 0.4.0

### DIFF
--- a/packages/ccextractor/CHANGELOG.md
+++ b/packages/ccextractor/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Changed from default exports to named exports.
+- Update the required version of appliance-core to 0.4.0
 
 ### Added
 - Now exports the `CCExtractorLine` object because why not.

--- a/packages/ccextractor/package.json
+++ b/packages/ccextractor/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.3.0",
+    "@tvkitchen/appliance-core": "0.4.0",
     "@tvkitchen/base-classes": "^1.3.0",
     "@tvkitchen/base-constants": "^1.0.1",
     "command-exists": "^1.2.9"

--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Changed from default exports to named exports.
+- Update the required version of appliance-core to 0.4.0
 
 ## [0.1.1] - 2020-09-10
 ### Changed

--- a/packages/video-file-ingestion/package.json
+++ b/packages/video-file-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.3.1"
+    "@tvkitchen/appliance-core": "0.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/video-http-ingestion/CHANGELOG.md
+++ b/packages/video-http-ingestion/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Changed from default exports to named exports.
+- Update the required version of appliance-core to 0.4.0
 
 ## [0.1.1] - 2020-09-16
 ### Changed

--- a/packages/video-http-ingestion/package.json
+++ b/packages/video-http-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.3.1",
+    "@tvkitchen/appliance-core": "0.4.0",
     "node-fetch": "^2.6.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,18 +1028,6 @@
   dependencies:
     type-detect "4.0.8"
 
-"@tvkitchen/appliance-core@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/appliance-core/-/appliance-core-0.3.0.tgz#eab8e9b882dc9d46e56b586427b0ccce14f8d38d"
-  integrity sha512-s6muzgQNGzCVVZJEKP4mQVVgKu1RmbAwbRw4u6zutE5uRodrK18xTaJRP5JXJ8jYW6JmBRMrGUfhBAPw0xdpCA==
-  dependencies:
-    "@tvkitchen/base-classes" "^1.3.0"
-    "@tvkitchen/base-constants" "^1.2.0"
-    "@tvkitchen/base-errors" "^1.0.1"
-    "@tvkitchen/base-interfaces" "4.0.0-alpha.2"
-    command-exists "^1.2.9"
-    ts-demuxer "^1.0.0"
-
 "@tvkitchen/base-classes@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"


### PR DESCRIPTION
## Description
This PR updates the appliance-core version to `0.4.0` in order to bring the ffmpeg bug fix forward to the appliances themselves.

## Related Issues
Related to #53
