### PR TITLE
Update core to use Transform IAppliances

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase the `base-interfaces` version dependency to `4.0.0-alpha.3`.
+- Remove built in support for event emission from `AbstractAppliance`.
+- Update `AbstractVideoIngestionAppliance` to use the `Transform` API, and no longer emit custom events.
+
+### Added
+- `AbstractAppliance` now accepts a `logger` parameter.
+
 ## [0.4.0]
 ### Changed
 - Changed from default exports to named exports (internally).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "@tvkitchen/base-classes": "^1.3.0",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.1",
-    "@tvkitchen/base-interfaces": "4.0.0-alpha.2",
+    "@tvkitchen/base-interfaces": "4.0.0-alpha.3",
     "command-exists": "^1.2.9",
     "ts-demuxer": "^1.0.0"
   },

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -1,11 +1,11 @@
 import assert from 'assert'
-import EventEmitter from 'events'
 import { AbstractInstantiationError } from '@tvkitchen/base-errors'
 import { IAppliance } from '@tvkitchen/base-interfaces'
 import {
 	Payload,
 	PayloadArray,
 } from '@tvkitchen/base-classes'
+import { silentLogger } from './silentLogger'
 
 /**
  * The Abstract Appliance begins to implement the IAppliance interface and implements
@@ -21,19 +21,18 @@ import {
 class AbstractAppliance extends IAppliance {
 	settings = {}
 
-	emitter = new EventEmitter()
-
 	payloads = new PayloadArray()
 
 	constructor(settings = {}) {
-		super()
+		super(settings)
 		if (this.constructor === AbstractAppliance) {
 			throw new AbstractInstantiationError('AbstractAppliance')
 		}
-		Object.assign(
-			this.settings,
-			settings,
-		)
+		this.settings = {
+			logger: silentLogger,
+			...settings,
+		}
+		this.logger = this.settings.logger
 	}
 
 	/** @inheritdoc */
@@ -65,18 +64,6 @@ class AbstractAppliance extends IAppliance {
 		this.payloads = remainingPayloads
 		return werePayloadsProcessed
 	}
-
-	/** @inheritdoc */
-	on = (eventType, listener) => this.emitter.on(eventType, listener)
-
-  /**
-   * Emits an event to listeners.
-   *
-   * @param  {String} event The event type to emit.
-   * @param  {Object} args  Any associated data to include in the event.
-   * @return {Boolean} Returns true if the event had listeners, false otherwise.
-   */
-  emit = (event, ...args) => this.emitter.emit(event, ...args)
 }
 
 export { AbstractAppliance }

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -6,10 +6,7 @@ import {
 } from 'stream'
 import commandExists from 'command-exists'
 import { Payload } from '@tvkitchen/base-classes'
-import {
-	dataTypes,
-	applianceEvents,
-} from '@tvkitchen/base-constants'
+import { dataTypes } from '@tvkitchen/base-constants'
 import {
 	AbstractInstantiationError,
 	NotImplementedError,
@@ -64,7 +61,7 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 		this.payloadIngestionStream = Writable({
 			objectMode: true,
 			write: (payload, enc, done) => {
-				this.emit(applianceEvents.PAYLOAD, payload)
+				this.push(payload)
 				done()
 			},
 		})
@@ -155,7 +152,6 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 
 	/** @inheritdoc */
 	start = async () => {
-		this.emit(applianceEvents.STARTING)
 		this.ffmpegProcess = spawn(
 			'ffmpeg',
 			this.getFfmpegSettings(),
@@ -171,13 +167,11 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 			this.payloadIngestionStream,
 			() => this.stop(),
 		)
-		this.emit(applianceEvents.READY)
 		return true
 	}
 
 	/** @inheritdoc */
 	stop = async () => {
-		this.emit(applianceEvents.STOPPING)
 		if (this.activeInputStream !== null) {
 			this.activeInputStream.destroy()
 		}
@@ -185,7 +179,6 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 			this.ffmpegProcess.kill()
 		}
 		this.logger.info(`Ended ingestion from ${this.constructor.name}...`)
-		this.emit(applianceEvents.STOPPED)
 		return true
 	}
 

--- a/packages/core/src/__test__/AbstractAppliance.test.js
+++ b/packages/core/src/__test__/AbstractAppliance.test.js
@@ -4,7 +4,6 @@ import {
 	Payload,
 	PayloadArray,
 } from '@tvkitchen/base-classes'
-import { applianceEvents } from '@tvkitchen/base-constants'
 import { AbstractAppliance } from '../AbstractAppliance'
 import {
 	FullyImplementedAppliance,
@@ -105,22 +104,6 @@ describe('AbstractAppliance #unit', () => {
 			)
 			implementedAppliance.invoke = jest.fn().mockReturnValueOnce(remainingPayloads)
 			expect(await implementedAppliance.ingestPayload(payload)).toBe(false)
-		})
-	})
-
-	describe('emit', () => {
-		it('should emit an event of the specified type', () => {
-			const implementedAppliance = new FullyImplementedAppliance()
-			const emitSpy = jest.spyOn(implementedAppliance.emitter, 'emit')
-			implementedAppliance.emit(applianceEvents.STARTING)
-			expect(emitSpy).toBeCalledWith(applianceEvents.STARTING)
-		})
-		it('should emit an event with specified args', () => {
-			const implementedAppliance = new FullyImplementedAppliance()
-			const payload = getValidPayload()
-			const emitSpy = jest.spyOn(implementedAppliance.emitter, 'emit')
-			implementedAppliance.emit(applianceEvents.PAYLOAD, payload)
-			expect(emitSpy).toBeCalledWith(applianceEvents.PAYLOAD, payload)
 		})
 	})
 })

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -131,7 +131,9 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 				stdin: new Writable(),
 			})
 			const inputStream = new Readable({ read: () => {} })
-			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance(inputStream)
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance({
+				readableStream: inputStream,
+			})
 			ingestionAppliance.producer = { connect: jest.fn().mockResolvedValue() }
 			ingestionAppliance.start()
 			expect(childProcess.spawn).toHaveBeenCalledTimes(1)
@@ -144,7 +146,9 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 			})
 			childProcess.spawn.mockReturnValueOnce({})
 			const inputStream = new Readable({ read: jest.fn() })
-			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance(inputStream)
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance({
+				readableStream: inputStream,
+			})
 			ingestionAppliance.producer = { connect: jest.fn().mockResolvedValue() }
 			await ingestionAppliance.start()
 			expect(stream.pipeline).toHaveBeenCalledTimes(1)

--- a/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
@@ -1,9 +1,9 @@
 import { AbstractVideoIngestionAppliance } from '../../AbstractVideoIngestionAppliance'
 
 class FullyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppliance {
-	constructor(readableStream) {
-		super()
-		this.readableStream = readableStream
+	constructor(settings = {}) {
+		super(settings)
+		this.readableStream = settings.readableStream
 	}
 
 	getInputStream = () => this.readableStream

--- a/packages/core/src/silentLogger.js
+++ b/packages/core/src/silentLogger.js
@@ -1,0 +1,15 @@
+import { logLevels } from '@tvkitchen/base-constants'
+
+const log = () => {}
+
+const silentLogger = {
+	log,
+	fatal: log.bind(this, logLevels.fatal),
+	error: log.bind(this, logLevels.error),
+	warn: log.bind(this, logLevels.warn),
+	info: log.bind(this, logLevels.info),
+	debug: log.bind(this, logLevels.debug),
+	trace: log.bind(this, logLevels.trace),
+}
+
+export { silentLogger }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,7 +1033,7 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
   integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
 
-"@tvkitchen/base-constants@^1.0.1", "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
+"@tvkitchen/base-constants@^1.0.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-constants/-/base-constants-1.2.0.tgz#020246bd1ff700e67066eea2e708dc5254cbcb9d"
   integrity sha512-9oyAYcMwWH1NiM9kFJ6yxameRBb58gq3/NCPBcXxVRe8IdHnQ3XKVC0fw0J3pfeOgOHayEeVTtEcSx4FlhilOw==
@@ -1043,12 +1043,11 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-errors/-/base-errors-1.0.1.tgz#1117e17c8a0888989ad155d1318d03b6a6ab942f"
   integrity sha512-AHb+LYbughr1dggUFiAA7y079ZRrjgLiW2KOJgeHbQXSr1kcaxcAnISUV8e1EYuUODhmN1FD8ka9T0d9+RLzKQ==
 
-"@tvkitchen/base-interfaces@4.0.0-alpha.2":
-  version "4.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.2.tgz#9eee6837a0a8b33828186bef7564bb1084816e0e"
-  integrity sha512-B+clkl+hHVQNJ5nLgQWC+0Q22g/X0/UqWLRFLDE5sBBx1QzyxJm6Dp3miBvgcU9lJS/aqpsljEuNDY2hHTrzKw==
+"@tvkitchen/base-interfaces@4.0.0-alpha.3":
+  version "4.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.3.tgz#bedc37666e5c2798d704d657d93d02d8e27db7c6"
+  integrity sha512-e5y75kEbtacqhGyBSSf4WlPeVY9OrIx6N581JVvBKZbyauyRPT6dRtGix0Avt2NkndNIwGc8LiNPJVuOmq4k8w==
   dependencies:
-    "@tvkitchen/base-constants" "^1.1.1"
     "@tvkitchen/base-errors" "^1.0.0"
 
 "@types/babel__core@^7.1.7":


### PR DESCRIPTION
## Description
This PR updates the appliance-core to use the Transform based IAppliance.

Appliances that extend `AbstractAppliance` will need to be updated to use the Transform API.

## Related Issues
Related to #59 
