### PR TITLE
Update CCExtractor appliance

### DIFF
--- a/packages/ccextractor/package.json
+++ b/packages/ccextractor/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.4.0",
+    "@tvkitchen/appliance-core": "0.5.0",
     "@tvkitchen/base-classes": "^1.3.0",
     "@tvkitchen/base-constants": "^1.0.1",
     "command-exists": "^1.2.9"

--- a/packages/ccextractor/src/CCExtractorAppliance.js
+++ b/packages/ccextractor/src/CCExtractorAppliance.js
@@ -3,10 +3,7 @@ import commandExists from 'command-exists'
 import {
 	PayloadArray,
 } from '@tvkitchen/base-classes'
-import {
-	dataTypes,
-	applianceEvents,
-} from '@tvkitchen/base-constants'
+import { dataTypes } from '@tvkitchen/base-constants'
 import { AbstractAppliance } from '@tvkitchen/appliance-core'
 import {
 	parseCcExtractorLines,
@@ -38,7 +35,7 @@ class CCExtractorAppliance extends AbstractAppliance {
 				return convertCcExtractorLineToPayload(line, previousLine)
 			})
 			.filter((payload) => payload.data !== '')
-		payloads.forEach((payload) => this.emit(applianceEvents.PAYLOAD, payload))
+		payloads.forEach((payload) => this.push(payload))
 	}
 
 	/** @inheritdoc */
@@ -53,7 +50,6 @@ class CCExtractorAppliance extends AbstractAppliance {
 
 	/** @inheritdoc */
 	start = async () => {
-		this.emit(applianceEvents.STARTING)
 		this.ccExtractorProcess = spawn('ccextractor', [
 			'-stdout',
 			'--stream',
@@ -64,16 +60,13 @@ class CCExtractorAppliance extends AbstractAppliance {
 			'-',
 		])
 		this.ccExtractorProcess.stdout.on('data', this.handleCcExtractorData)
-		this.emit(applianceEvents.READY)
 	}
 
 	/** @inheritdoc */
 	stop = async () => {
-		this.emit(applianceEvents.STOPPING)
 		if (this.ccExtractorProcess !== null) {
 			this.ccExtractorProcess.kill()
 		}
-		this.emit(applianceEvents.STOPPED)
 	}
 
 	/** @inheritdoc */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,18 @@
   dependencies:
     type-detect "4.0.8"
 
+"@tvkitchen/appliance-core@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/appliance-core/-/appliance-core-0.5.0.tgz#8934d5693852b6fa3a1b34dea5cd562598953738"
+  integrity sha512-AIsG9I5hsOZjd/WRGXzB/IjarlkaYm/9eAiyzSstunXEPERlyfJMbdcsIsEAk+PQlR+blQKT9qxlr5cwNZFrIw==
+  dependencies:
+    "@tvkitchen/base-classes" "^1.3.0"
+    "@tvkitchen/base-constants" "^1.2.0"
+    "@tvkitchen/base-errors" "^1.0.1"
+    "@tvkitchen/base-interfaces" "4.0.0-alpha.3"
+    command-exists "^1.2.9"
+    ts-demuxer "^1.0.0"
+
 "@tvkitchen/base-classes@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"


### PR DESCRIPTION
## Description
This PR updates the CCExtractorAppliance to use the latest version of `@tvkitchen/appliance-core`.  The primary change is that it now uses the node stream API.

## Related Issues
Resolves #59 
