### PR TITLE
Update video ingestion appliances

### DIFF
--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update the required version of appliance-core to 0.5.0
 
 ## [0.1.1] - 2020-09-10
 ### Changed

--- a/packages/video-file-ingestion/package.json
+++ b/packages/video-file-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.4.0"
+    "@tvkitchen/appliance-core": "0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/video-http-ingestion/CHANGELOG.md
+++ b/packages/video-http-ingestion/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update the required version of appliance-core to 0.5.0
 
 ## [0.2.0] - 2020-09-22
 ### Changed

--- a/packages/video-http-ingestion/package.json
+++ b/packages/video-http-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.4.0",
+    "@tvkitchen/appliance-core": "0.5.0",
     "node-fetch": "^2.6.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,18 +1028,6 @@
   dependencies:
     type-detect "4.0.8"
 
-"@tvkitchen/appliance-core@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/appliance-core/-/appliance-core-0.5.0.tgz#8934d5693852b6fa3a1b34dea5cd562598953738"
-  integrity sha512-AIsG9I5hsOZjd/WRGXzB/IjarlkaYm/9eAiyzSstunXEPERlyfJMbdcsIsEAk+PQlR+blQKT9qxlr5cwNZFrIw==
-  dependencies:
-    "@tvkitchen/base-classes" "^1.3.0"
-    "@tvkitchen/base-constants" "^1.2.0"
-    "@tvkitchen/base-errors" "^1.0.1"
-    "@tvkitchen/base-interfaces" "4.0.0-alpha.3"
-    command-exists "^1.2.9"
-    ts-demuxer "^1.0.0"
-
 "@tvkitchen/base-classes@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"


### PR DESCRIPTION
## Description
This PR updates the video ingestion appliances to use the latest version of appliance-core (and therefore support the node stream API)

## Related Issues
Related to #59 
