### PR TITLE
Emit newline payloads

### DIFF
--- a/packages/ccextractor/CHANGELOG.md
+++ b/packages/ccextractor/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Emit newline atoms (`\n`) when a new caption line has started.
 
 ## [0.3.0] 2020-10-18
 ### Changed

--- a/packages/ccextractor/src/CCExtractorAppliance.js
+++ b/packages/ccextractor/src/CCExtractorAppliance.js
@@ -7,7 +7,7 @@ import { dataTypes } from '@tvkitchen/base-constants'
 import { AbstractAppliance } from '@tvkitchen/appliance-core'
 import {
 	parseCcExtractorLines,
-	convertCcExtractorLineToPayload,
+	convertCcExtractorLineToPayloads,
 } from './utils/ccextractor'
 
 class CCExtractorAppliance extends AbstractAppliance {
@@ -29,10 +29,10 @@ class CCExtractorAppliance extends AbstractAppliance {
 		const lines = parseCcExtractorLines(data.toString())
 		const payloads = lines
 			.filter((line) => line.text !== '')
-			.map((line) => {
+			.flatMap((line) => {
 				const previousLine = this.mostRecentLine
 				this.mostRecentLine = line
-				return convertCcExtractorLineToPayload(line, previousLine)
+				return convertCcExtractorLineToPayloads(line, previousLine)
 			})
 			.filter((payload) => payload.data !== '')
 		payloads.forEach((payload) => this.push(payload))

--- a/packages/ccextractor/src/utils/__test__/__snapshots__/ccextractor.unit.test.js.snap
+++ b/packages/ccextractor/src/utils/__test__/__snapshots__/ccextractor.unit.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ccextractor utils #unit convertCcExtractorLineToPayloads should convert a single line 1`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": "CLEANUP GUY AND IF YOU L",
+  "duration": 834,
+  "position": 58892,
+  "timestamp": "",
+  "type": "TEXT.ATOM",
+}
+`;
+
+exports[`ccextractor utils #unit convertCcExtractorLineToPayloads should convert the diff between two lines 1`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": "OO",
+  "duration": 33,
+  "position": 59726,
+  "timestamp": "",
+  "type": "TEXT.ATOM",
+}
+`;
+
+exports[`ccextractor utils #unit convertCcExtractorLineToPayloads should detect and emit new lines 1`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": "
+",
+  "duration": 0,
+  "position": 59726,
+  "timestamp": "",
+  "type": "TEXT.ATOM",
+}
+`;
+
+exports[`ccextractor utils #unit convertCcExtractorLineToPayloads should detect and emit new lines 2`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": "He was as fresh as is the month of May.",
+  "duration": 33,
+  "position": 59726,
+  "timestamp": "",
+  "type": "TEXT.ATOM",
+}
+`;

--- a/packages/ccextractor/src/utils/__test__/ccextractor.unit.test.js
+++ b/packages/ccextractor/src/utils/__test__/ccextractor.unit.test.js
@@ -1,9 +1,8 @@
-import { Payload } from '@tvkitchen/base-classes'
 import {
 	parseCcExtractorLine,
 	parseCcExtractorLines,
 	ccExtractorTimestampToMs,
-	convertCcExtractorLineToPayload,
+	convertCcExtractorLineToPayloads,
 } from '../ccextractor'
 import { CCExtractorLine } from '../../CCExtractorLine'
 
@@ -69,22 +68,19 @@ lol this is not valid`))
 			expect(ccExtractorTimestampToMs('90:11:14,123')).toBe(324674123)
 		})
 	})
-	describe('convertCcExtractorLineToPayload', () => {
+	describe('convertCcExtractorLineToPayloads', () => {
 		it('should convert a single line', () => {
 			const ccExtractorLine = new CCExtractorLine({
 				start: 58892,
 				end: 59726,
 				text: 'CLEANUP GUY AND IF YOU L',
 			})
-			const payload = convertCcExtractorLineToPayload(ccExtractorLine)
-			const targetPayload = new Payload({
-				position: 58892,
-				duration: 834,
-				data: 'CLEANUP GUY AND IF YOU L',
+			const payloads = convertCcExtractorLineToPayloads(ccExtractorLine)
+			payloads.forEach((payload) => {
+				expect(payload).toMatchSnapshot({
+					createdAt: expect.any(String),
+				})
 			})
-			expect(payload.position).toEqual(targetPayload.position)
-			expect(payload.duration).toEqual(targetPayload.duration)
-			expect(payload.data).toEqual(targetPayload.data)
 		})
 		it('should convert the diff between two lines', () => {
 			const previousLine = new CCExtractorLine({
@@ -97,10 +93,30 @@ lol this is not valid`))
 				end: 59759,
 				text: 'CLEANUP GUY AND IF YOU LOO',
 			})
-			const payload = convertCcExtractorLineToPayload(newLine, previousLine)
-			expect(payload.position).toEqual(59726)
-			expect(payload.duration).toEqual(33)
-			expect(payload.data).toEqual('OO')
+			const payloads = convertCcExtractorLineToPayloads(newLine, previousLine)
+			payloads.forEach((payload) => {
+				expect(payload).toMatchSnapshot({
+					createdAt: expect.any(String),
+				})
+			})
+		})
+		it('should detect and emit new lines', () => {
+			const previousLine = new CCExtractorLine({
+				start: 58892,
+				end: 59726,
+				text: 'Singing he was, or fluting all the day;',
+			})
+			const newLine = new CCExtractorLine({
+				start: 58892,
+				end: 59759,
+				text: 'He was as fresh as is the month of May.',
+			})
+			const payloads = convertCcExtractorLineToPayloads(newLine, previousLine)
+			payloads.forEach((payload) => {
+				expect(payload).toMatchSnapshot({
+					createdAt: expect.any(String),
+				})
+			})
 		})
 	})
 })

--- a/packages/ccextractor/src/utils/ccextractor.js
+++ b/packages/ccextractor/src/utils/ccextractor.js
@@ -77,14 +77,25 @@ export const parseCcExtractorLines = (str) => str
  * @param  {CCExtractorLine} previousLine [description]
  * @return {[type]}      [description]
  */
-export const convertCcExtractorLineToPayload = (line, previousLine = null) => {
+export const convertCcExtractorLineToPayloads = (line, previousLine = null) => {
 	const newCharacters = getDiff(line.text, previousLine ? previousLine.text : '')
+	const isNewLine = (newCharacters === line.text)
 	const start = previousLine ? previousLine.end : line.start
 	const { end } = line
-	return new Payload({
+	const payloads = []
+	if (isNewLine && previousLine !== null) {
+		payloads.push(new Payload({
+			data: '\n',
+			type: dataTypes.TEXT.ATOM,
+			position: start,
+			duration: 0,
+		}))
+	}
+	payloads.push(new Payload({
 		data: newCharacters,
 		type: dataTypes.TEXT.ATOM,
 		position: start,
 		duration: end - start,
-	})
+	}))
+	return payloads
 }


### PR DESCRIPTION
## Description
This PR fixes a bug where the caption extraction would not emit newlines on caption line breaks.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Related Issues
Resolves #66 
