### PR TITLE
Support timestamp in video ingestor appliances

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `AbstractVideoIngestionAppliance` now generates payloads with timestamps, and accepts an `origin` setting on appliance construction.
 
 ## [0.5.0] - 2020-10-18
 ### Changed

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -80,7 +80,7 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 				expect(result.data).toEqual(streamData)
 			})
 		})
-		it('should correctly decorate the Payload with time', () => {
+		it('should correctly decorate the Payload position', () => {
 			jest.clearAllMocks()
 			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
 			ingestionAppliance.mpegtsDemuxer = {
@@ -92,7 +92,39 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 			const streamData = Buffer.from('testDataXYZ', 'utf8')
 			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
 				expect(result.position).toEqual(1000)
+			})
+		})
+		it('should correctly decorate the Payload createdAt', () => {
+			jest.clearAllMocks()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
+			ingestionAppliance.mpegtsDemuxer = {
+				process: jest.fn(),
+			}
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({
+				pts: 90000,
+			})
+			const streamData = Buffer.from('testDataXYZ', 'utf8')
+			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
 				expect(typeof result.createdAt).toBe('string')
+			})
+		})
+		it('should correctly decorate the Payload timestamp', () => {
+			jest.clearAllMocks()
+			const originTime = new Date()
+			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance({
+				origin: originTime.toISOString(),
+			})
+			ingestionAppliance.mpegtsDemuxer = {
+				process: jest.fn(),
+			}
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({
+				pts: 90000,
+			})
+			const streamData = Buffer.from('testDataXYZ', 'utf8')
+			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
+				expect(result.timestamp).toEqual(
+					(new Date(originTime.getTime() + 1000)).toISOString(),
+				)
 			})
 		})
 	})


### PR DESCRIPTION
## Description
This PR adds support for the `timestamp` attribute for video ingestion appliances.

It also adds a new optional `origin` setting for ingestion appliances, which allows a TV Kitchen implementation to indicate what time a given video stream started (e.g. if the stream is delayed, or is pre-recorded).

## Related Issues
Related to #76 
