### PR TITLE
Allow null invoke returns

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `AbstractVideoIngestionAppliance` now generates payloads with timestamps, and accepts an `origin` setting on appliance construction.
 
+### Changed
+- `AbstractAppliance` no longer errors if `invoke` returns a null value.
+
 ## [0.5.0] - 2020-10-18
 ### Changed
 - Increase the `base-interfaces` version dependency to `4.0.0-alpha.3`.

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -55,7 +55,7 @@ class AbstractAppliance extends IAppliance {
 			'Payload does not satisfy appliance ingestion conditions.',
 		)
 		this.payloads.insert(payload)
-		const remainingPayloads = await this.invoke(this.payloads)
+		const remainingPayloads = (await this.invoke(this.payloads)) ?? new PayloadArray()
 		assert(
 			PayloadArray.isPayloadArray(remainingPayloads),
 			'The invoke method was not properly defined; it must return a PayloadArray.',

--- a/packages/core/src/__test__/AbstractAppliance.test.js
+++ b/packages/core/src/__test__/AbstractAppliance.test.js
@@ -88,6 +88,13 @@ describe('AbstractAppliance #unit', () => {
 			expect(implementedAppliance.payloads).toBe(remainingPayloads)
 		})
 
+		it('should return true if invoke returns null', async () => {
+			const implementedAppliance = new FullyImplementedAppliance()
+			const payload = getValidPayload()
+			implementedAppliance.invoke = jest.fn().mockReturnValueOnce(null)
+			expect(await implementedAppliance.ingestPayload(payload)).toBe(true)
+		})
+
 		it('should return true if invoke returns an empty payload array', async () => {
 			const implementedAppliance = new FullyImplementedAppliance()
 			const payload = getValidPayload()


### PR DESCRIPTION
## Description
This PR fixes an issue where `invoke` could not return null without triggering an error.

## Related Issues
Resolves #74
