### PR TITLE
Update appliances to use appliance-core@0.6.1

### DIFF
--- a/packages/caption-srt-generator/CHANGELOG.md
+++ b/packages/caption-srt-generator/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+### Changed
+- Update the required version of appliance-core to 0.6.1
+
 ## [0.1.0] - 2021-02-19
 ### Added
 - Initial implementation of the `CaptionSrtGenerator` appliance.
 
+[Unreleased]: https://github.com/tvkitchen/appliances/compare/@tvkitchen/appliance-caption-srt-generator@0.1.0...HEAD
 [0.1.0]: https://github.com/tvkitchen/appliances/releases/tag/@tvkitchen/appliance-caption-srt-generator@0.1.0
 
 

--- a/packages/caption-srt-generator/package.json
+++ b/packages/caption-srt-generator/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.5.0",
+    "@tvkitchen/appliance-core": "0.6.1",
     "@tvkitchen/base-classes": "^1.3.0",
     "@tvkitchen/base-constants": "^1.0.1",
     "dayjs": "^1.10.4"

--- a/packages/ccextractor/CHANGELOG.md
+++ b/packages/ccextractor/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Update the required version of appliance-core to 0.6.1
+
 ## [0.3.1]
 ### Changed
 - Emit newline atoms (`\n`) when a new caption line has started.

--- a/packages/ccextractor/package.json
+++ b/packages/ccextractor/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.5.0",
+    "@tvkitchen/appliance-core": "0.6.1",
     "@tvkitchen/base-classes": "^1.3.0",
     "@tvkitchen/base-constants": "^1.0.1",
     "command-exists": "^1.2.9"

--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Fixed the way default settings were specified for individual fields.
+- Update the required version of appliance-core to 0.6.1
 
 ## [0.3.0] - 2020-10-18
 ### Changed
@@ -31,5 +32,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/tvkitchen/appliances/releases/tag/@tvkitchen/appliance-video-file-ingestion@0.2.0
 [0.1.1]: https://github.com/tvkitchen/appliances/releases/tag/@tvkitchen/appliance-video-file-ingestion@0.1.1
 [0.1.0]: https://github.com/tvkitchen/appliances/releases/tag/@tvkitchen/appliance-video-file-ingestion@0.1.0
-
-

--- a/packages/video-file-ingestion/package.json
+++ b/packages/video-file-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.5.0"
+    "@tvkitchen/appliance-core": "0.6.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/video-http-ingestion/CHANGELOG.md
+++ b/packages/video-http-ingestion/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Fixed the way default settings were specified for individual fields.
+- Update the required version of appliance-core to 0.6.1
 
 ## [0.3.0] - 2020-10-18
 ### Changed

--- a/packages/video-http-ingestion/package.json
+++ b/packages/video-http-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.5.0",
+    "@tvkitchen/appliance-core": "0.6.1",
     "node-fetch": "^2.6.1"
   },
   "publishConfig": {

--- a/packages/video-segment-generator/CHANGELOG.md
+++ b/packages/video-segment-generator/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update the required version of appliance-core to 0.6.1
 
 ## [0.1.0] - 2021-04-07
 ### Added

--- a/packages/video-segment-generator/README.md
+++ b/packages/video-segment-generator/README.md
@@ -10,7 +10,7 @@ The Video Segment Generator Appliance will take a stream of payloads and identif
 ## Configuration Options
 The appliance takes in the following configuration values:
 
-- `period` (milliseconds): the number of milliseconds that the clock will track (e.g. 60000 would be a clock that can track up to one minute).  Default is `PERIOD.INFINITE`.
+- `interval` (milliseconds): the number of milliseconds that the clock will track (e.g. 60000 would be a clock that can track up to one minute).  Default is `INTERVALS.INFINITE`.
 
 - `origin` (timestamp): what time does the clock start (what is the first instance of "0" when identifying segments).  Default is `now()`
 

--- a/packages/video-segment-generator/package.json
+++ b/packages/video-segment-generator/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.5.0",
+    "@tvkitchen/appliance-core": "0.6.1",
     "@tvkitchen/base-classes": "^1.3.0",
     "@tvkitchen/base-constants": "^1.0.1",
     "dayjs": "^1.10.4"


### PR DESCRIPTION
This should fix the broken build while also giving appliances access to
the latest base-class features

Issue #84

## Description
This PR updates all appliances to use the latest appliance-core version

## Related Issues
Resolves #84 
