### PR TITLE
Filter corrupt packets

### DIFF
--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -82,6 +82,8 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 */
 	getFfmpegSettings = () => [
 		'-loglevel', 'quiet',
+		'-err_detect', 'aggressive',
+		'-fflags', 'discardcorrupt',
 		'-i', '-',
 		'-codec', 'copy',
 		'-f', 'mpegts',


### PR DESCRIPTION
## Description
This PR adds flags so that ffmpeg will filter corrupt mpegts stream packets before TVK ingests the content.

The flags set are [documented here](https://ffmpeg.org/ffmpeg-codecs.html).

## Related Issues
Resolves #94