### PR TITLE
Add segment support to the SRT Generator

### DIFF
--- a/packages/caption-srt-generator/CHANGELOG.md
+++ b/packages/caption-srt-generator/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update the required version of appliance-core to 0.6.1
 - Update the referenced base dependencies.
 
+### Added
+- Support for responding to `SEGMENT.START` payloads.
+
 ## [0.1.0] - 2021-02-19
 ### Added
 - Initial implementation of the `CaptionSrtGenerator` appliance.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update `AbstractVideoIngestionAppliance` to filter corrupt payloads.
 
 ## [0.6.1] - 2020-04-07
 ### Added


### PR DESCRIPTION
## Description
This PR adds support for segments in the SRT generation.  This is needed because the actual content of the SRT payloads need to change based on segments (for instance timestamps and counters reset to zero on a new segment)

## Related Issues
Resolves #92 
