### PR TITLE
Remove arrow functions from core

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
 - Update `@tvkitchen/base-interfaces` to version `4.0.0-alpha.4`.
+- Update `AbstractVideoIngestionAppliance` to populate Payload `origin` instead of `timestamp`.
+- Remove arrow function method definitions from `AbstractVideoIngestionAppliance` and `AbstractAppliance`.
 
 ## [0.6.1] - 2020-04-07
 ### Added

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Update `AbstractVideoIngestionAppliance` to filter corrupt payloads.
 
+### Changed
+- Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
+- Update `@tvkitchen/base-interfaces` to version `4.0.0-alpha.4`.
+
 ## [0.6.1] - 2020-04-07
 ### Added
 - `AbstractVideoIngestionAppliance` now generates payloads with timestamps, and accepts an `origin` setting on appliance construction.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,10 +11,10 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/base-classes": "^1.4.0-alpha.2",
+    "@tvkitchen/base-classes": "^2.0.0-alpha.1",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.1",
-    "@tvkitchen/base-interfaces": "4.0.0-alpha.3",
+    "@tvkitchen/base-interfaces": "4.0.0-alpha.4",
     "command-exists": "^1.2.9",
     "ts-demuxer": "^1.0.0"
   },

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -36,7 +36,7 @@ class AbstractAppliance extends IAppliance {
 	}
 
 	/** @inheritdoc */
-	isValidPayload = async (payload) => {
+	async isValidPayload(payload) {
 		assert(
 			this.constructor.getInputTypes().includes(payload.type),
 			`${payload.type} is not a valid Payload type for this appliance.`,
@@ -45,7 +45,7 @@ class AbstractAppliance extends IAppliance {
 	}
 
 	/** @inheritdoc */
-	ingestPayload = async (payload) => {
+	async ingestPayload(payload) {
 		assert(
 			Payload.isPayload(payload),
 			'You cannot ingest data that is not an instance of Payload.',

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -81,15 +81,17 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 *
 	 * @return {String[]} A list of FFmpeg command line parameters
 	 */
-	getFfmpegSettings = () => [
-		'-loglevel', 'quiet',
-		'-err_detect', 'aggressive',
-		'-fflags', 'discardcorrupt',
-		'-i', '-',
-		'-codec', 'copy',
-		'-f', 'mpegts',
-		'-',
-	]
+	static getFfmpegSettings() {
+		return [
+			'-loglevel', 'quiet',
+			'-err_detect', 'aggressive',
+			'-fflags', 'discardcorrupt',
+			'-i', '-',
+			'-codec', 'copy',
+			'-f', 'mpegts',
+			'-',
+		]
+	}
 
 	/**
 	 * The ReadableStream that is being ingested by the ingestion engine.
@@ -98,7 +100,8 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 *
 	 * @return {ReadableStream} The stream of data to be ingested by the ingestion engine
 	 */
-	getInputStream = () => {
+	// eslint-disable-next-line class-methods-use-this
+	getInputStream() {
 		throw new NotImplementedError('getInputStream')
 	}
 
@@ -110,7 +113,7 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 *
 	 * @param  {Packet} packet The latest TSDemuxer Packet object
 	 */
-	onDemuxedPacket = (packet) => {
+	onDemuxedPacket(packet) {
 		this.mostRecentDemuxedPacket = packet
 	}
 
@@ -121,7 +124,9 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 *
 	 * @return {Packet} The most recent Packet object extracted by TSDemuxer
 	 */
-	getMostRecentDemuxedPacket = () => this.mostRecentDemuxedPacket
+	getMostRecentDemuxedPacket() {
+		return this.mostRecentDemuxedPacket
+	}
 
 	/**
 	 * Process a new chunk of data from an MPEG-TS stream. The chunks passed to this
@@ -135,7 +140,7 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	 * @param  {Function(err,result)} done     A `(err, result) => ...` callback
 	 *
 	 */
-	processMpegtsStreamData = (mpegtsData, enc, done) => {
+	processMpegtsStreamData(mpegtsData, enc, done) {
 		this.mpegtsDemuxer.process(mpegtsData)
 		const demuxedPacket = this.getMostRecentDemuxedPacket() || generateEmptyPacket()
 		const position = tsToMilliseconds(demuxedPacket.pts)
@@ -151,10 +156,13 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	}
 
 	/** @inheritdoc */
-	isValidPayload = async () => true
+	// eslint-disable-next-line class-methods-use-this
+	async isValidPayload() {
+		return true
+	}
 
 	/** @inheritdoc */
-	audit = async () => {
+	async audit() {
 		let passed = true
 		if (!commandExists.sync('ffmpeg')) {
 			passed = false
@@ -164,10 +172,10 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	}
 
 	/** @inheritdoc */
-	start = async () => {
+	async start() {
 		this.ffmpegProcess = spawn(
 			'ffmpeg',
-			this.getFfmpegSettings(),
+			this.constructor.getFfmpegSettings(),
 			{ stdio: ['pipe', 'pipe', 'ignore'] },
 		)
 		this.activeInputStream = this.getInputStream()
@@ -184,7 +192,7 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	}
 
 	/** @inheritdoc */
-	stop = async () => {
+	async stop() {
 		if (this.activeInputStream !== null) {
 			this.activeInputStream.destroy()
 		}
@@ -196,15 +204,20 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	}
 
 	/** @inheritdoc */
-	invoke = async () => {
+	// eslint-disable-next-line class-methods-use-this
+	async invoke() {
 		throw new Error('Ingestion Appliances cannot be invoked.')
 	}
 
 	/** @inheritdoc */
-	static getInputTypes = () => []
+	static getInputTypes() {
+		return []
+	}
 
 	/** @inheritdoc */
-	static getOutputTypes = () => [dataTypes.STREAM.CONTAINER]
+	static getOutputTypes() {
+		return [dataTypes.STREAM.CONTAINER]
+	}
 }
 
 export { AbstractVideoIngestionAppliance }

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -48,7 +48,8 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 	/**
 	* Create a AbstractVideoIngestionAppliance.
 	*
-	* @param  {String} settings.origin The ISO timestamp thaat marks the timestamp of position 0.
+	* @param  {String} settings.origin The ISO timestamp that marks the absoulte time associated
+	*                                  with position 0.
 	*/
 	constructor(settings = {}) {
 		super({
@@ -138,14 +139,13 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 		this.mpegtsDemuxer.process(mpegtsData)
 		const demuxedPacket = this.getMostRecentDemuxedPacket() || generateEmptyPacket()
 		const position = tsToMilliseconds(demuxedPacket.pts)
-		const timestampInMs = (new Date(this.settings.origin)).getTime() + position
 		const payload = new Payload({
 			data: mpegtsData,
 			type: dataTypes.STREAM.CONTAINER,
 			duration: 0,
 			position,
 			createdAt: (new Date()).toISOString(),
-			timestamp: (new Date(timestampInMs)).toISOString(),
+			origin: this.settings.origin,
 		})
 		done(null, payload)
 	}

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -212,17 +212,16 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 		})
 	})
 
-	describe('getFfmpegSettings', () => {
-		it('should return an array', () => {
-			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
-			expect(ingestionAppliance.getFfmpegSettings()).toBeInstanceOf(Array)
-		})
-	})
-
 	describe('getInputStream', () => {
 		it('should throw an error when called without an implementation', () => {
 			const ingestionAppliance = new PartiallyImplementedVideoIngestionAppliance()
 			expect(ingestionAppliance.getInputStream).toThrow(NotImplementedError)
+		})
+	})
+
+	describe('getFfmpegSettings', () => {
+		it('should return an array', () => {
+			expect(AbstractVideoIngestionAppliance.getFfmpegSettings()).toBeInstanceOf(Array)
 		})
 	})
 

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -108,7 +108,7 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 				expect(typeof result.createdAt).toBe('string')
 			})
 		})
-		it('should correctly decorate the Payload timestamp', () => {
+		it('should correctly decorate the Payload origin', () => {
 			jest.clearAllMocks()
 			const originTime = new Date()
 			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance({
@@ -122,9 +122,7 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 			})
 			const streamData = Buffer.from('testDataXYZ', 'utf8')
 			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
-				expect(result.timestamp).toEqual(
-					(new Date(originTime.getTime() + 1000)).toISOString(),
-				)
+				expect(result.origin).toEqual(originTime.toISOString())
 			})
 		})
 	})

--- a/packages/core/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedAppliance.js
@@ -1,9 +1,13 @@
 import { AbstractAppliance } from '../../AbstractAppliance'
 
 class FullyImplementedAppliance extends AbstractAppliance {
-	static getInputTypes = () => ['FOO']
+	static getInputTypes() {
+		return ['FOO']
+	}
 
-	static getOutputTypes = () => ['BAR']
+	static getOutputTypes() {
+		return ['BAR']
+	}
 
 	invoke = async (payloads) => payloads
 }

--- a/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedVideoIngestionAppliance.js
@@ -6,7 +6,9 @@ class FullyImplementedVideoIngestionAppliance extends AbstractVideoIngestionAppl
 		this.readableStream = settings.readableStream
 	}
 
-	getInputStream = () => this.readableStream
+	getInputStream() {
+		return this.readableStream
+	}
 }
 
 export { FullyImplementedVideoIngestionAppliance }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,7 +1028,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@tvkitchen/base-classes@1.4.0-alpha.2", "@tvkitchen/base-classes@^1.4.0-alpha.2":
+"@tvkitchen/base-classes@1.4.0-alpha.2":
   version "1.4.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.4.0-alpha.2.tgz#8bf355433bd088d5a2fa07de00d25105dcdfcc9a"
   integrity sha512-xH0PS08AObEG2ZxnOrAbMBAb8ReMm8dwTd8ZKK5OyNAU4tSQmx8pLx4JQQIkwckms37RJM4VOrw5Wvulh44ExA==
@@ -1040,6 +1040,13 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
   integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
 
+"@tvkitchen/base-classes@^2.0.0-alpha.1":
+  version "2.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-2.0.0-alpha.1.tgz#a52e7d39ee814c1a9f9293e199f99a93adb4a0c8"
+  integrity sha512-1wENKO3VTnV7BY/OeMGJ7N7gub1zIlQ/AU+MQu9q/73/iNV1sZkCiFKbVXd8lnSd2gwzGio4Eca5vOA2S7Zl8A==
+  dependencies:
+    avsc "^5.4.21"
+
 "@tvkitchen/base-constants@1.2.0", "@tvkitchen/base-constants@^1.0.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-constants/-/base-constants-1.2.0.tgz#020246bd1ff700e67066eea2e708dc5254cbcb9d"
@@ -1050,10 +1057,10 @@
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-errors/-/base-errors-1.0.1.tgz#1117e17c8a0888989ad155d1318d03b6a6ab942f"
   integrity sha512-AHb+LYbughr1dggUFiAA7y079ZRrjgLiW2KOJgeHbQXSr1kcaxcAnISUV8e1EYuUODhmN1FD8ka9T0d9+RLzKQ==
 
-"@tvkitchen/base-interfaces@4.0.0-alpha.3":
-  version "4.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.3.tgz#bedc37666e5c2798d704d657d93d02d8e27db7c6"
-  integrity sha512-e5y75kEbtacqhGyBSSf4WlPeVY9OrIx6N581JVvBKZbyauyRPT6dRtGix0Avt2NkndNIwGc8LiNPJVuOmq4k8w==
+"@tvkitchen/base-interfaces@4.0.0-alpha.4":
+  version "4.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.4.tgz#c0820e455c0965de4d49b0c582dddc7013a86b42"
+  integrity sha512-mX/YrsrT3a9HAKEjxuT4D/TRMtN/XuLZKKi9BypHUB9wNwynOg84HrECWaMrSsJGLGn1zUmJk6HtjM2a/CJK9g==
   dependencies:
     "@tvkitchen/base-errors" "^1.0.0"
 


### PR DESCRIPTION
## Description
This PR removes arrow functions from core class method definitions.

It also updates the AbstractIngestionAppliance to decorate `origin` instead of `timestamp`

## Related Issues
Resolves #100 