### PR TITLE
Support `origin` Payloads

### DIFF
--- a/packages/caption-srt-generator/CHANGELOG.md
+++ b/packages/caption-srt-generator/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
 - Update the required version of appliance-core to 0.6.1
 - Update the referenced base dependencies.
 

--- a/packages/caption-srt-generator/package.json
+++ b/packages/caption-srt-generator/package.json
@@ -12,7 +12,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@tvkitchen/appliance-core": "0.6.1",
-    "@tvkitchen/base-classes": "1.4.0-alpha.2",
+    "@tvkitchen/base-classes": "2.0.0-alpha.1",
     "@tvkitchen/base-constants": "1.2.0",
     "dayjs": "^1.10.4"
   },

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -64,6 +64,17 @@ class AbstractAppliance extends IAppliance {
 		this.payloads = remainingPayloads
 		return werePayloadsProcessed
 	}
+
+	push(payload) {
+		const origin = (payload.origin === '')
+			? this.payloads.getOrigin()
+			: payload.origin
+
+		super.push(new Payload({
+			...payload,
+			origin,
+		}))
+	}
 }
 
 export { AbstractAppliance }

--- a/packages/core/src/__test__/classes/FullyImplementedAppliance.js
+++ b/packages/core/src/__test__/classes/FullyImplementedAppliance.js
@@ -9,7 +9,8 @@ class FullyImplementedAppliance extends AbstractAppliance {
 		return ['BAR']
 	}
 
-	invoke = async (payloads) => payloads
+	// eslint-disable-next-line class-methods-use-this
+	async invoke(payloads) { return payloads }
 }
 
 export { FullyImplementedAppliance }

--- a/packages/video-caption-extractor/CHANGELOG.md
+++ b/packages/video-caption-extractor/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
 
 ## [0.4.0] - 2021-04-21
 - Update the required version of appliance-core to 0.6.1

--- a/packages/video-caption-extractor/package.json
+++ b/packages/video-caption-extractor/package.json
@@ -12,7 +12,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@tvkitchen/appliance-core": "0.6.1",
-    "@tvkitchen/base-classes": "^1.3.0",
+    "@tvkitchen/base-classes": "2.0.0-alpha.1",
     "@tvkitchen/base-constants": "^1.0.1",
     "command-exists": "^1.2.9"
   },

--- a/packages/video-caption-extractor/src/utils/__test__/__snapshots__/ccextractor.unit.test.js.snap
+++ b/packages/video-caption-extractor/src/utils/__test__/__snapshots__/ccextractor.unit.test.js.snap
@@ -5,8 +5,8 @@ Object {
   "createdAt": Any<String>,
   "data": "CLEANUP GUY AND IF YOU L",
   "duration": 834,
+  "origin": "",
   "position": 58892,
-  "timestamp": "",
   "type": "TEXT.ATOM",
 }
 `;
@@ -16,8 +16,8 @@ Object {
   "createdAt": Any<String>,
   "data": "OO",
   "duration": 33,
+  "origin": "",
   "position": 59726,
-  "timestamp": "",
   "type": "TEXT.ATOM",
 }
 `;
@@ -28,8 +28,8 @@ Object {
   "data": "
 ",
   "duration": 0,
+  "origin": "",
   "position": 59726,
-  "timestamp": "",
   "type": "TEXT.ATOM",
 }
 `;
@@ -39,8 +39,8 @@ Object {
   "createdAt": Any<String>,
   "data": "He was as fresh as is the month of May.",
   "duration": 33,
+  "origin": "",
   "position": 59726,
-  "timestamp": "",
   "type": "TEXT.ATOM",
 }
 `;

--- a/packages/video-segment-generator/CHANGELOG.md
+++ b/packages/video-segment-generator/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
+
 ### Fixed
 - Fixed a bug where non-zero originPositions would result in incorrect periodPositions.
 

--- a/packages/video-segment-generator/package.json
+++ b/packages/video-segment-generator/package.json
@@ -12,7 +12,7 @@
   "module": "src/index.js",
   "dependencies": {
     "@tvkitchen/appliance-core": "0.6.1",
-    "@tvkitchen/base-classes": "^1.3.0",
+    "@tvkitchen/base-classes": "2.0.0-alpha.1",
     "@tvkitchen/base-constants": "^1.0.1",
     "dayjs": "^1.10.4"
   },

--- a/packages/video-segment-generator/src/utils/__test__/__snapshots__/segment.test.js.snap
+++ b/packages/video-segment-generator/src/utils/__test__/__snapshots__/segment.test.js.snap
@@ -44,8 +44,8 @@ Object {
     "type": "Buffer",
   },
   "duration": 0,
+  "origin": "",
   "position": 0,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -55,8 +55,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 500,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -105,8 +105,8 @@ Object {
     "type": "Buffer",
   },
   "duration": 0,
+  "origin": "",
   "position": 0,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -156,8 +156,8 @@ Object {
     "type": "Buffer",
   },
   "duration": 0,
+  "origin": "",
   "position": 300000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -167,8 +167,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 0,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -178,8 +178,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 1,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -189,8 +189,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 2,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -200,8 +200,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 3,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -211,8 +211,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 2000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -222,8 +222,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 2000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -233,8 +233,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 3000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -244,8 +244,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 4000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -255,8 +255,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 0,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -266,8 +266,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 1000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -277,8 +277,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 2000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -288,8 +288,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 3000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -299,8 +299,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 4000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -310,8 +310,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 5000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;
@@ -321,8 +321,8 @@ Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
+  "origin": "",
   "position": 6000,
-  "timestamp": "",
   "type": "SEGMENT.START",
 }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,19 +1028,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@tvkitchen/base-classes@1.4.0-alpha.2":
-  version "1.4.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.4.0-alpha.2.tgz#8bf355433bd088d5a2fa07de00d25105dcdfcc9a"
-  integrity sha512-xH0PS08AObEG2ZxnOrAbMBAb8ReMm8dwTd8ZKK5OyNAU4tSQmx8pLx4JQQIkwckms37RJM4VOrw5Wvulh44ExA==
-  dependencies:
-    avsc "^5.4.21"
-
-"@tvkitchen/base-classes@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
-  integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
-
-"@tvkitchen/base-classes@^2.0.0-alpha.1":
+"@tvkitchen/base-classes@2.0.0-alpha.1", "@tvkitchen/base-classes@^2.0.0-alpha.1":
   version "2.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-2.0.0-alpha.1.tgz#a52e7d39ee814c1a9f9293e199f99a93adb4a0c8"
   integrity sha512-1wENKO3VTnV7BY/OeMGJ7N7gub1zIlQ/AU+MQu9q/73/iNV1sZkCiFKbVXd8lnSd2gwzGio4Eca5vOA2S7Zl8A==


### PR DESCRIPTION
## Description
This PR updates appliances so that they all use the new `origin` Payloads (as opposed to `timestamp` Payloads).

This PR also updates the appliance core classes so that appliances will now all generate payloads with populated `origin` values.

## Related Issues
Resolves #103 