### PR TITLE
Some origin fixes

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `AbstractAppliance` will now populate the `origin` of outbound payloads.
 - Update `AbstractVideoIngestionAppliance` to filter corrupt payloads.
 
 ### Changed

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -33,7 +33,12 @@ class AbstractAppliance extends IAppliance {
 			...settings,
 		}
 		this.logger = this.settings.logger
+		this.currentOrigin = ''
 	}
+
+	setCurrentOrigin(origin) { this.currentOrigin = origin }
+
+	getCurrentOrigin() { return this.currentOrigin }
 
 	/** @inheritdoc */
 	async isValidPayload(payload) {
@@ -55,6 +60,7 @@ class AbstractAppliance extends IAppliance {
 			'Payload does not satisfy appliance ingestion conditions.',
 		)
 		this.payloads.insert(payload)
+		this.setCurrentOrigin(payload.origin)
 		const remainingPayloads = (await this.invoke(this.payloads)) ?? new PayloadArray()
 		assert(
 			PayloadArray.isPayloadArray(remainingPayloads),
@@ -67,7 +73,7 @@ class AbstractAppliance extends IAppliance {
 
 	push(payload) {
 		const origin = (payload.origin === '')
-			? this.payloads.getOrigin()
+			? this.getCurrentOrigin()
 			: payload.origin
 
 		super.push(new Payload({

--- a/packages/core/src/AbstractVideoIngestionAppliance.js
+++ b/packages/core/src/AbstractVideoIngestionAppliance.js
@@ -60,11 +60,11 @@ class AbstractVideoIngestionAppliance extends AbstractAppliance {
 			throw new AbstractInstantiationError(this.constructor.name)
 		}
 
-		this.mpegtsDemuxer = new TSDemuxer(this.onDemuxedPacket)
+		this.mpegtsDemuxer = new TSDemuxer(this.onDemuxedPacket.bind(this))
 
 		this.mpegtsProcessingStream = Transform({
 			objectMode: true,
-			transform: this.processMpegtsStreamData,
+			transform: this.processMpegtsStreamData.bind(this),
 		})
 
 		this.payloadIngestionStream = Writable({


### PR DESCRIPTION
## Description
This PR fixes an issue where origin was not being properly looked up and applied to outbound payloads.

It also fixes an issue with the `AbstractVideoIngestionAppliance` where it event handlers were not being properly bound to `this`.

## Related Issues
Related to #103 