### PR TITLE
Refactor segment generator

### DIFF
--- a/packages/video-segment-generator/CHANGELOG.md
+++ b/packages/video-segment-generator/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
+- Update to support `origin` payloads instead of `timestamp`.
+- Change `origin` appliance parameter to `startingAt`.
 
 ### Fixed
 - Fixed a bug where non-zero originPositions would result in incorrect periodPositions.

--- a/packages/video-segment-generator/README.md
+++ b/packages/video-segment-generator/README.md
@@ -12,7 +12,7 @@ The appliance takes in the following configuration values:
 
 - `interval` (milliseconds): the number of milliseconds that the clock will track (e.g. 60000 would be a clock that can track up to one minute).  Default is `INTERVALS.INFINITE`.
 
-- `origin` (ISO String): what time does the clock start (what is the first instance of "0" when identifying segments).  Default is the ISO string value for the time of instantiation.
+- `startingAt` (ISO String): what is the absolute time of the beginning of the first interval.  Default is the ISO string value for the time of instantiation.
 
 - `segments`: array of objects and / or numbers specifying segment start times.  If the value is an object the `offset` attribute is used to convey the segment start offset.  Default is `[0]`.
 	- `offset` (milliseconds): the period offset that demarks the start of the segment.

--- a/packages/video-segment-generator/src/utils/__test__/__snapshots__/segment.test.js.snap
+++ b/packages/video-segment-generator/src/utils/__test__/__snapshots__/segment.test.js.snap
@@ -1,6 +1,127 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for mixed segments 1`] = `
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate a subset of segments for positions overlap multiple intervals 1`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 2000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate a subset of segments for positions overlap multiple intervals 2`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 3000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate a subset of segments for positions overlap multiple intervals 3`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 4000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate all segments if there is an infinite interval 1`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 2000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 1`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 0,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 2`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 1000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 3`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 2000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 4`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 3000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 5`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 4000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 6`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 5000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsForPositionRange should generate multiple sets of segments for positions that span multiple intervals 7`] = `
+Object {
+  "createdAt": Any<String>,
+  "data": null,
+  "duration": 0,
+  "origin": "",
+  "position": 6000,
+  "type": "SEGMENT.START",
+}
+`;
+
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for mixed segments 1`] = `
 Object {
   "createdAt": Any<String>,
   "data": Object {
@@ -50,7 +171,7 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for mixed segments 2`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for mixed segments 2`] = `
 Object {
   "createdAt": Any<String>,
   "data": null,
@@ -61,7 +182,7 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for object segments 1`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for object segments 1`] = `
 Object {
   "createdAt": Any<String>,
   "data": Object {
@@ -111,7 +232,7 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for object segments 2`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for object segments 2`] = `
 Object {
   "createdAt": Any<String>,
   "data": Object {
@@ -162,7 +283,7 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for simple segments 1`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for simple segments 1`] = `
 Object {
   "createdAt": Any<String>,
   "data": null,
@@ -173,7 +294,7 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for simple segments 2`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for simple segments 2`] = `
 Object {
   "createdAt": Any<String>,
   "data": null,
@@ -184,7 +305,7 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for simple segments 3`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for simple segments 3`] = `
 Object {
   "createdAt": Any<String>,
   "data": null,
@@ -195,134 +316,13 @@ Object {
 }
 `;
 
-exports[`segment utils #unit generatePeriodSegmentPayloads should generate payloads for simple segments 4`] = `
+exports[`segment utils #unit generateSegmentPayloadsFromPosition should generate payloads for simple segments 4`] = `
 Object {
   "createdAt": Any<String>,
   "data": null,
   "duration": 0,
   "origin": "",
   "position": 3,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate a segments if there is an infinite interval 1`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 2000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate a subset of segments for positions overlap multiple intervals 1`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 2000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate a subset of segments for positions overlap multiple intervals 2`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 3000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate a subset of segments for positions overlap multiple intervals 3`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 4000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 1`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 0,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 2`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 1000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 3`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 2000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 4`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 3000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 5`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 4000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 6`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 5000,
-  "type": "SEGMENT.START",
-}
-`;
-
-exports[`segment utils #unit generatePositionRangeSegmentPayloads should generate multiple sets of segments for positions that span multiple intervals 7`] = `
-Object {
-  "createdAt": Any<String>,
-  "data": null,
-  "duration": 0,
-  "origin": "",
-  "position": 6000,
   "type": "SEGMENT.START",
 }
 `;

--- a/packages/video-segment-generator/src/utils/__test__/segment.test.js
+++ b/packages/video-segment-generator/src/utils/__test__/segment.test.js
@@ -1,41 +1,38 @@
 import {
-	calculateOriginPosition,
-	generatePeriodSegmentPayloads,
-	generatePositionRangeSegmentPayloads,
+	calculateStartingPosition,
+	generateSegmentPayloadsFromPosition,
+	generateSegmentPayloadsForPositionRange,
 	getPeriodPosition,
 } from '../segment'
 
 import { INTERVALS } from '../../constants'
 
 describe('segment utils #unit', () => {
-	describe('calculateOriginPosition', () => {
-		it('should return the reference position when passed matching timestamps', () => {
-			expect(calculateOriginPosition(
+	describe('calculateStartingPosition', () => {
+		it('should return zero when passed matching timestamps', () => {
+			expect(calculateStartingPosition(
 				'2021-03-12T20:04:25.258Z',
 				'2021-03-12T20:04:25.258Z',
-				42,
-			)).toBe(42)
+			)).toBe(0)
 		})
-		it('should generate negative origin positions if origin is before position 0', () => {
-			expect(calculateOriginPosition(
+		it('should generate negative positions if startAt is before the reference origin', () => {
+			expect(calculateStartingPosition(
 				'2021-03-12T20:04:24.258Z',
 				'2021-03-12T20:04:25.258Z',
-				0,
 			)).toBe(-1000)
 		})
-		it('should generate positive origin positions if origin is after position 0', () => {
-			expect(calculateOriginPosition(
+		it('should generate positive positions if startAt is after the reference origin', () => {
+			expect(calculateStartingPosition(
 				'2021-03-12T20:04:26.258Z',
 				'2021-03-12T20:04:25.258Z',
-				0,
 			)).toBe(1000)
 		})
 	})
 
-	describe('generatePeriodSegmentPayloads', () => {
+	describe('generateSegmentPayloadsFromPosition', () => {
 		it('should generate payloads for simple segments', () => {
 			const segments = [0, 1, 2, 3]
-			const segmentPayloads = generatePeriodSegmentPayloads(0, segments)
+			const segmentPayloads = generateSegmentPayloadsFromPosition(0, segments)
 			segmentPayloads.forEach((segmentPayload) => expect(segmentPayload).toMatchSnapshot({
 				createdAt: expect.any(String),
 			}))
@@ -52,7 +49,7 @@ describe('segment utils #unit', () => {
 					programName: 'The Second Segment',
 				},
 			}]
-			const segmentPayloads = generatePeriodSegmentPayloads(0, segments)
+			const segmentPayloads = generateSegmentPayloadsFromPosition(0, segments)
 			expect(segmentPayloads.length).toBe(2)
 			segmentPayloads.forEach((segmentPayload) => expect(segmentPayload).toMatchSnapshot({
 				createdAt: expect.any(String),
@@ -65,7 +62,7 @@ describe('segment utils #unit', () => {
 					programName: 'The First Segment',
 				},
 			}, 500]
-			const segmentPayloads = generatePeriodSegmentPayloads(0, segments)
+			const segmentPayloads = generateSegmentPayloadsFromPosition(0, segments)
 			expect(segmentPayloads.length).toBe(2)
 			segmentPayloads.forEach((segmentPayload) => expect(segmentPayload).toMatchSnapshot({
 				createdAt: expect.any(String),
@@ -90,17 +87,17 @@ describe('segment utils #unit', () => {
 		})
 	})
 
-	describe('generatePositionRangeSegmentPayloads', () => {
+	describe('generateSegmentPayloadsForPositionRange', () => {
 		it('should generate multiple sets of segments for positions that span multiple intervals', () => {
-			const startPosition = 0
-			const endPosition = 6000
-			const originPosition = 0
+			const rangeStartPosition = 0
+			const rangeEndPosition = 6000
+			const startingPosition = 0
 			const interval = 3000
 			const segments = [0, 1000, 2000]
-			const segmentPayloads = generatePositionRangeSegmentPayloads(
-				startPosition,
-				endPosition,
-				originPosition,
+			const segmentPayloads = generateSegmentPayloadsForPositionRange(
+				rangeStartPosition,
+				rangeEndPosition,
+				startingPosition,
 				interval,
 				segments,
 			)
@@ -111,15 +108,15 @@ describe('segment utils #unit', () => {
 		})
 
 		it('should generate a subset of segments for positions overlap multiple intervals', () => {
-			const startPosition = 2000
-			const endPosition = 4000
-			const originPosition = 0
+			const rangeStartPosition = 2000
+			const rangeEndPosition = 4000
+			const startingPosition = 0
 			const interval = 3000
 			const segments = [0, 1000, 2000]
-			const segmentPayloads = generatePositionRangeSegmentPayloads(
-				startPosition,
-				endPosition,
-				originPosition,
+			const segmentPayloads = generateSegmentPayloadsForPositionRange(
+				rangeStartPosition,
+				rangeEndPosition,
+				startingPosition,
 				interval,
 				segments,
 			)
@@ -129,16 +126,16 @@ describe('segment utils #unit', () => {
 			}))
 		})
 
-		it('should generate a segments if there is an infinite interval', () => {
-			const startPosition = 2000
-			const endPosition = 4000
-			const originPosition = 0
+		it('should generate all segments if there is an infinite interval', () => {
+			const rangeStartPosition = 2000
+			const rangeEndPosition = 4000
+			const startingPosition = 0
 			const interval = INTERVALS.INFINITE
 			const segments = [0, 1000, 2000]
-			const segmentPayloads = generatePositionRangeSegmentPayloads(
-				startPosition,
-				endPosition,
-				originPosition,
+			const segmentPayloads = generateSegmentPayloadsForPositionRange(
+				rangeStartPosition,
+				rangeEndPosition,
+				startingPosition,
 				interval,
 				segments,
 			)

--- a/packages/video-segment-generator/src/utils/segment.js
+++ b/packages/video-segment-generator/src/utils/segment.js
@@ -3,21 +3,21 @@ import { Payload } from '@tvkitchen/base-classes'
 import { INTERVALS } from '../constants'
 
 /**
- * Calculates the position associated with the origin time when compared to a reference
- * position / timestamp pair.  This origin position might be negative (e.g. if the origin
- * happened before the start of the reference stream)
+ * Calculates the interal segmenter position associated with a given frame's zero reference.
+ * This starting position might be negative (e.g. if the zero reference happened before
+ * the start of the reference stream).
  *
- * @param  {String} originTimestamp    The ISO string associated with the origin time.
- * @param  {String} referenceTimestamp The ISO string associated with the reference time.
- * @param  {Number} referencePosition  The payload associated with th ereference time.
- * @return {Number}                    The origin payload when compared to the reference stream.
+ * @param  {String} startingTimestamp      The ISO string associated with the segmenter internal
+ *                                         zero position.
+ * @param  {String} zeroReferenceTimestamp The ISO string associated with an external zero position.
+ * @return {Number}                        The position associated with the segmenter's start.
  */
-export const calculateOriginPosition = (originTimestamp, referenceTimestamp, referencePosition) => (
-	dayjs(originTimestamp).diff(dayjs(referenceTimestamp)) + referencePosition
+export const calculateStartingPosition = (startingTimestamp, zeroReferenceTimestamp) => (
+	dayjs(startingTimestamp).diff(dayjs(zeroReferenceTimestamp))
 )
 
 /**
- * Generates a complete set of payments for the period starting at a given position.
+ * Generates a complete set of payments starting from a given position.
  *
  * Segments can either be represented as an integer (the offset) or as an object with offset
  * and data values.
@@ -26,7 +26,7 @@ export const calculateOriginPosition = (originTimestamp, referenceTimestamp, ref
  * @param  {object[]} segments     The segments being used to generate payloads.
  * @return {Payload[]}             The resulting segment payloads.
  */
-export const generatePeriodSegmentPayloads = (periodPosition, segments) => segments.map(
+export const generateSegmentPayloadsFromPosition = (periodPosition, segments) => segments.map(
 	(segment) => {
 		const data = Number.isInteger(segment) ? null : Buffer.from(JSON.stringify(segment.data))
 		const offset = Number.isInteger(segment) ? segment : segment.offset
@@ -44,16 +44,19 @@ export const generatePeriodSegmentPayloads = (periodPosition, segments) => segme
  *
  * A zero value for interval will always return the originPosition.
  *
- * @param  {Number} position       The position being checked
- * @param  {Number} originPosition The starting position of the first period
- * @param  {Number} interval       The period interval size
- * @return {Number}                The starting position of the containing period
+ * @param  {Number} position                  The position being checked
+ * @param  {Number} segmenterStartingPosition The starting position of the first period
+ * @param  {Number} interval                  The period interval size
+ * @return {Number}                           The starting position of the containing period
  */
-export const getPeriodPosition = (position, originPosition, interval) => (
-	(interval === INTERVALS.INFINITE)
-		? originPosition
-		: Math.floor((position - originPosition) / interval) * interval + originPosition
-)
+export const getPeriodPosition = (position, segmenterStartingPosition, interval) => {
+	if (interval === INTERVALS.INFINITE) {
+		return segmenterStartingPosition
+	}
+	const offsetPosition = Math.floor((position - segmenterStartingPosition) / interval) * interval
+	return segmenterStartingPosition + offsetPosition
+}
+
 
 /**
  * Creates an array of values.
@@ -78,34 +81,45 @@ const range = (start, count, step) => Array.from(
  * The start and end position are inclusive, which means that segments whose positions match
  * the start or end position will be included in the result.
  *
- * @param  {Number} startPosition  The earliest segment position to generate.
- * @param  {Number} endPosition    The latest segment position to generate.
- * @param  {Number} originPosition The origin position, used to calculate segment positions.
- * @param  {Number} interval       The interval being used to generate segment sets.
- * @param  {object[]} segments     The segments being generated.
- * @return {Payload[]}             The resulting Payloads
+ * @param  {Number} rangeStartPosition        The earliest segment position to generate.
+ * @param  {Number} rangeEndPosition          The latest segment position to generate.
+ * @param  {Number} segmenterStartingPosition The zero position of the segmenter.
+ * @param  {Number} interval                  The interval being used to generate segment sets.
+ * @param  {object[]} segments                The segments being generated.
+ * @return {Payload[]}                        The resulting Payloads
  */
-export const generatePositionRangeSegmentPayloads = (
-	startPosition,
-	endPosition,
-	originPosition,
+export const generateSegmentPayloadsForPositionRange = (
+	rangeStartPosition,
+	rangeEndPosition,
+	segmenterStartingPosition,
 	interval,
 	segments,
 ) => {
 	let segmentPayloads = []
 	if (interval === INTERVALS.INFINITE) {
-		segmentPayloads = generatePeriodSegmentPayloads(originPosition, segments)
+		segmentPayloads = generateSegmentPayloadsFromPosition(
+			segmenterStartingPosition,
+			segments,
+		)
 	} else {
-		const startPeriodPosition = getPeriodPosition(startPosition, originPosition, interval)
-		const endPeriodPosition = getPeriodPosition(endPosition, originPosition, interval)
+		const startPeriodPosition = getPeriodPosition(
+			rangeStartPosition,
+			segmenterStartingPosition,
+			interval,
+		)
+		const endPeriodPosition = getPeriodPosition(
+			rangeEndPosition,
+			segmenterStartingPosition,
+			interval,
+		)
 		const periodCount = Math.floor((endPeriodPosition - startPeriodPosition) / interval) + 1
 		const periodPositions = range(startPeriodPosition, periodCount, interval)
 		segmentPayloads = periodPositions.flatMap(
-			(periodPosition) => generatePeriodSegmentPayloads(periodPosition, segments),
+			(periodPosition) => generateSegmentPayloadsFromPosition(periodPosition, segments),
 		)
 	}
 	return segmentPayloads.filter((segment) => (
-		segment.position >= startPosition
-		&& segment.position <= endPosition
+		segment.position >= rangeStartPosition
+		&& segment.position <= rangeEndPosition
 	))
 }


### PR DESCRIPTION
The VideoSegmentGenerator appliance was using the old `timestamp` field
and needed to be updated to use `origin`.  This also helped highlight
some of the difficult-to-parse variable and method names.

Instead of using `origin` in the segment appliance, it is `startingAt`
which has more intuitive meaning.  Some of the internal methods have
been reworded as well with the goal of legibility.

Issue #103

## Description
This PR updates the `VideoSegmentGeneratorAppliance` to use the new `origin` Payload.

This also involved renaming some internal variables and methods so the term `origin` wouldn't be overloaded.

Note that it's hard to name variables that exist to resolve two separate time frames that are moving forward in parallel... but I do think these names are an improvement.

## Related Issues
Related to #103 
