### PR TITLE
Fix appliance documentation formatting (Issue #102)

### DIFF
--- a/packages/caption-srt-generator/README.md
+++ b/packages/caption-srt-generator/README.md
@@ -1,9 +1,9 @@
 # TV Kitchen Caption SRT Generator Appliance
 
----
+```
 inputTypes: TEXT.ATOM
 outputTypes: TEXT.SRT
----
+```
 
 The Caption SRT Generator appliance ingests a stream of captions and converts them into the [SubRip file format](https://en.wikipedia.org/wiki/SubRip).
 

--- a/packages/video-caption-extractor/README.md
+++ b/packages/video-caption-extractor/README.md
@@ -1,9 +1,9 @@
 # TV Kitchen Video Caption Extractor Appliance
 
----
+```
 inputTypes: STREAM.CONTAINER
 outputTypes: TEXT.ATOM
----
+```
 
 The Caption appliance consumes `STREAM.CONTAINER` payloads and produces `TEXT.ATOM` payloads which reflect the closed captions of the stream.
 

--- a/packages/video-file-ingestion/README.md
+++ b/packages/video-file-ingestion/README.md
@@ -1,9 +1,9 @@
 # TV Kitchen Video File Ingestion Appliance
 
----
+```
 inputTypes: none
 outputTypes: STREAM.CONTAINER
----
+```
 
 The Video File Ingestion appliance is configured to ingest a video file and conver it into `STREAM.CONTAINER` payloads.
 

--- a/packages/video-http-ingestion/README.md
+++ b/packages/video-http-ingestion/README.md
@@ -1,9 +1,9 @@
 # TV Kitchen Video HTTP Ingestion Appliance
 
----
+```
 inputTypes: none
 outputTypes: STREAM.CONTAINER
----
+```
 
 The Video HTTP Ingestion appliance is configured to ingest a video URL and convert it into `STREAM.CONTAINER` payloads.
 

--- a/packages/video-segment-generator/README.md
+++ b/packages/video-segment-generator/README.md
@@ -1,9 +1,9 @@
 # TV Kitchen Video Segment Generator Appliance
 
----
+```
 inputTypes: STREAM.CONTAINER
 outputTypes: SEGMENT.START
----
+```
 
 The Video Segment Generator Appliance will take a stream of payloads and identify new segment starts according to the timestamp of those payloads.
 


### PR DESCRIPTION
## Description

Input and output table formatting in README.md files of each appliance
misrender in Github-flavored MD. This commit fixes that issue.

Issue #102

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [ ] Relevant labels assigned
- [ ] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
N/A

## Related Issues
Resolves #102 