### PR TITLE
Use mpegts-demuxer

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "@tvkitchen/base-errors": "^1.0.1",
     "@tvkitchen/base-interfaces": "4.0.0-alpha.4",
     "command-exists": "^1.2.9",
-    "ts-demuxer": "^1.0.0"
+    "mpegts-demuxer": "0.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -49,13 +49,13 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 		it('should pass the data to the mpegts demuxer', () => {
 			jest.clearAllMocks()
 			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
-			ingestionAppliance.mpegtsDemuxer = {
-				process: jest.fn(),
+			ingestionAppliance.mpegTsDemuxer = {
+				write: jest.fn(),
 			}
 			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({ pts: 0 })
 			const streamData = Buffer.from('testDataXYZ', 'utf8')
 			ingestionAppliance.processMpegtsStreamData(streamData, null, () => {
-				expect(ingestionAppliance.mpegtsDemuxer.process).toHaveBeenCalledTimes(1)
+				expect(ingestionAppliance.mpegTsDemuxer.write).toHaveBeenCalledTimes(1)
 			})
 		})
 		it('should emit a Payload of type STREAM.CONTAINER', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3642,6 +3642,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mpegts-demuxer@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/mpegts-demuxer/-/mpegts-demuxer-0.1.0.tgz#8bd256b7f2947952090bda6a818cd648da17a241"
+  integrity sha512-Hm2oFakIBd/9pOE2PDQCISVAPIczHCQAACxVFWMyghz02iLatRzJyHho7RyR9sSqHIyMrEniksETAmEo9l5Hpw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4952,11 +4957,6 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
-
-ts-demuxer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ts-demuxer/-/ts-demuxer-1.0.0.tgz#b0b873e7951a5a272e671acb82f622256d9eb891"
-  integrity sha512-76K1Tyb82CbawAUJ6Qz76TykS3SdgEWpJtE3GkUdBvOgdc/mkxns/1dDsViUNpmWZkBDWGBtnJl4EsYULc7Ruw==
 
 tslib@^1.9.0:
   version "1.11.1"


### PR DESCRIPTION
## Description
This PR changes our MPEG-TS demuxing script from `ts-demuxer` to our newly released `mpegts-demuxer`.

The forked version of the library changes the API to support NodeJS Streams, and also fixes a few of the bugs that we've recently uncovered related to timestamp extraction.

## Related Issues
Resolves #117 
Resolves #97 
Resolves #111 