### PR TITLE
Handle zero values in CCExtractorLines

### DIFF
--- a/packages/video-caption-extractor/CHANGELOG.md
+++ b/packages/video-caption-extractor/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
 
+### Fixed
+- No longer emits strange payloads when CCExtractor provides `00:00:00` timestamps.
+
 ## [0.4.0] - 2021-04-21
 - Update the required version of appliance-core to 0.6.1
 - Renamed the package from `@tvkitchen/appliance-ccextractor` to `@tvkitchen/appliance-video-caption-extractor`

--- a/packages/video-caption-extractor/src/utils/__test__/ccextractor.unit.test.js
+++ b/packages/video-caption-extractor/src/utils/__test__/ccextractor.unit.test.js
@@ -118,5 +118,33 @@ lol this is not valid`))
 				})
 			})
 		})
+		it('should use previous timestamp end as end if new end is zero', () => {
+			const previousLine = new CCExtractorLine({
+				start: 58892,
+				end: 59726,
+				text: 'Singing he was, or fluting all the day;',
+			})
+			const newLine = new CCExtractorLine({
+				start: 0,
+				end: 0,
+				text: 'He was as fresh as is the month of May.',
+			})
+			const payloads = convertCcExtractorLineToPayloads(newLine, previousLine)
+			expect(payloads[1].position).toBe(59726)
+		})
+		it('should use the current start if previous end is zero', () => {
+			const previousLine = new CCExtractorLine({
+				start: 58890,
+				end: 0,
+				text: 'Singing he was, or fluting all the day;',
+			})
+			const newLine = new CCExtractorLine({
+				start: 58892,
+				end: 58896,
+				text: 'He was as fresh as is the month of May.',
+			})
+			const payloads = convertCcExtractorLineToPayloads(newLine, previousLine)
+			expect(payloads[1].position).toBe(58892)
+		})
 	})
 })

--- a/packages/video-caption-extractor/src/utils/ccextractor.js
+++ b/packages/video-caption-extractor/src/utils/ccextractor.js
@@ -80,8 +80,12 @@ export const parseCcExtractorLines = (str) => str
 export const convertCcExtractorLineToPayloads = (line, previousLine = null) => {
 	const newCharacters = getDiff(line.text, previousLine ? previousLine.text : '')
 	const isNewLine = (newCharacters === line.text)
-	const start = previousLine ? previousLine.end : line.start
-	const { end } = line
+	const start = (previousLine && previousLine.end !== 0)
+		? previousLine.end
+		: line.start
+	const end = line.end !== 0
+		? line.end
+		: Math.max(previousLine.end, line.start)
 	const payloads = []
 	if (isNewLine && previousLine !== null) {
 		payloads.push(new Payload({


### PR DESCRIPTION
## Description
This PR fixes an issue where CCExtractor's occasional `00:00:00` timestamps for caption strings would create payloads with wild and crazy duration / position values.

## Related Issues
Resolves #109 
Resolves #107 