### PR TITLE
Remove hooks from base package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "clean": "rimraf packages/*/lib",
     "build": "yarn clean && yarn workspaces run babel --root-mode upward src -d lib",
     "lint": "eslint .",
-    "prepare": "yarn build",
-    "prepublishOnly": "yarn test && yarn lint",
-    "pretest": "yarn build",
     "test": "jest"
   },
   "files": [


### PR DESCRIPTION
## Description
This PR removes some yarn hooks that were just creating a bunch of noise on `test` and `lint`.

## Related Issues
Resolves #122 
