### PR TITLE
Update core to 0.7.0

### DIFF
--- a/packages/caption-srt-generator/CHANGELOG.md
+++ b/packages/caption-srt-generator/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
-- Update the required version of appliance-core to 0.6.1
+- Update `@tvkitchen/appliance-core` to version `0.7.0`.
 - Update the referenced base dependencies.
 
 ### Added

--- a/packages/caption-srt-generator/package.json
+++ b/packages/caption-srt-generator/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.6.1",
+    "@tvkitchen/appliance-core": "0.7.0",
     "@tvkitchen/base-classes": "2.0.0-alpha.1",
     "@tvkitchen/base-constants": "1.2.0",
     "dayjs": "^1.10.4"

--- a/packages/video-caption-extractor/CHANGELOG.md
+++ b/packages/video-caption-extractor/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
+- Update `@tvkitchen/appliance-core` to version `0.7.0`.
 
 ### Fixed
 - No longer emits strange payloads when CCExtractor provides `00:00:00` timestamps.

--- a/packages/video-caption-extractor/package.json
+++ b/packages/video-caption-extractor/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.6.1",
+    "@tvkitchen/appliance-core": "0.7.0",
     "@tvkitchen/base-classes": "2.0.0-alpha.1",
     "@tvkitchen/base-constants": "^1.0.1",
     "command-exists": "^1.2.9"

--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Update `@tvkitchen/appliance-core` to version `0.7.0`.
 
 ## [0.3.1] - 2021-04-21
 ### Changed

--- a/packages/video-file-ingestion/package.json
+++ b/packages/video-file-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.6.1"
+    "@tvkitchen/appliance-core": "0.7.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/video-http-ingestion/CHANGELOG.md
+++ b/packages/video-http-ingestion/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] - 2021-04-21
 ### Changed
 - Fixed the way default settings were specified for individual fields.
-- Update the required version of appliance-core to 0.6.1
+- Update `@tvkitchen/appliance-core` to version `0.7.0`.
 
 ## [0.3.0] - 2020-10-18
 ### Changed

--- a/packages/video-http-ingestion/package.json
+++ b/packages/video-http-ingestion/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.6.1",
+    "@tvkitchen/appliance-core": "0.7.0",
     "node-fetch": "^2.6.1"
   },
   "publishConfig": {

--- a/packages/video-segment-generator/CHANGELOG.md
+++ b/packages/video-segment-generator/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.
 - Update to support `origin` payloads instead of `timestamp`.
 - Change `origin` appliance parameter to `startingAt`.
+- Update `@tvkitchen/appliance-core` to version `0.7.0`.
 
 ### Fixed
 - Fixed a bug where non-zero originPositions would result in incorrect periodPositions.

--- a/packages/video-segment-generator/package.json
+++ b/packages/video-segment-generator/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.6.1",
+    "@tvkitchen/appliance-core": "0.7.0",
     "@tvkitchen/base-classes": "2.0.0-alpha.1",
     "@tvkitchen/base-constants": "^1.0.1",
     "dayjs": "^1.10.4"


### PR DESCRIPTION
## Description
This PR updates `@tvkitchen/appliance-core` to `0.7.0` for all appliances.

## Related Issues
I'm trying a thing where I don't make an issue for this kind of bulk version update, but that's probably not a good plan.