### PR TITLE
Handle PTS rollovers

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The optional `baseTime` parameter is now in terms of the fraction instead of the denominator of the fraction (e.g. `1/90000` instead of `90000`).
 
 ## [0.7.0] - 2020-05-13
 ### Added

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - The optional `baseTime` parameter is now in terms of the fraction instead of the denominator of the fraction (e.g. `1/90000` instead of `90000`).
+- `AbstractVideoIngestionAppliance` now supports streams that have been running long enough for a PTS rollover to occur.
 
 ## [0.7.0] - 2020-05-13
 ### Added

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -117,7 +117,7 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 			ingestionAppliance.mpegtsDemuxer = {
 				process: jest.fn(),
 			}
-			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({
+			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValue({
 				pts: 90000,
 			})
 			const streamData = Buffer.from('testDataXYZ', 'utf8')

--- a/packages/core/src/utils/__test__/mpegts.test.js
+++ b/packages/core/src/utils/__test__/mpegts.test.js
@@ -1,6 +1,8 @@
 import {
 	tsToMilliseconds,
 	generateEmptyPacket,
+	areDiscontinuousPositions,
+	getRolloverTimestamp,
 } from '../mpegts'
 
 describe('mpegts utilities', () => {
@@ -28,6 +30,53 @@ describe('mpegts utilities', () => {
 				content_type: 0,
 				frame_num: 0,
 			})
+		})
+	})
+
+	describe('areDiscontinuousPositions', () => {
+		it('should return false if positions are monotonically increasing', () => {
+			expect(areDiscontinuousPositions(0, 1)).toBe(false)
+			expect(areDiscontinuousPositions(0, 0)).toBe(false)
+			expect(areDiscontinuousPositions(1000, 15000)).toBe(false)
+		})
+
+		it('should return true if positions are decreasing', () => {
+			expect(areDiscontinuousPositions(10, 0)).toBe(true)
+			expect(areDiscontinuousPositions(0, -1)).toBe(true)
+			expect(areDiscontinuousPositions(10000, 5000)).toBe(true)
+		})
+	})
+
+	describe('getRolloverTimestamp', () => {
+		it('should not modify the timestamp if there are no rollovers', () => {
+			const baseTimestamp = '2021-06-30T18:30:25.205Z'
+			expect(getRolloverTimestamp(baseTimestamp, 0))
+				.toEqual(baseTimestamp)
+		})
+		it('should increase the timestamp by the default PTS rollover if there is a rollover', () => {
+			const baseTimestamp = '2021-06-30T18:30:25.205Z'
+			const singleRolloverTimestamp = '2021-07-01T21:01:08.922Z' // add 2^33 / 90000 seconds to the timestamp
+			expect(getRolloverTimestamp(baseTimestamp, 1))
+				.toEqual(singleRolloverTimestamp)
+		})
+		it('should default the rolloverCount to 1', () => {
+			const baseTimestamp = '2021-06-30T18:30:25.205Z'
+			const singleRolloverTimestamp = '2021-07-01T21:01:08.922Z' // add 2^33 / 90000 seconds to the timestamp
+			expect(getRolloverTimestamp(baseTimestamp))
+				.toEqual(singleRolloverTimestamp)
+		})
+		it('should increase the timestamp by the default PTS rollover multiple times if there is more than one rollover', () => {
+			const baseTimestamp = '2021-06-30T18:30:25.205Z'
+			const doubleRolloverTimestamp = '2021-07-02T23:31:52.640Z' // add 2 * 2^33 / 90000 seconds to the timestamp
+			expect(getRolloverTimestamp(baseTimestamp, 2))
+				.toEqual(doubleRolloverTimestamp)
+		})
+		it('should increase the timestamp based on the baseTime', () => {
+			const baseTimestamp = '2021-06-30T18:30:25.205Z'
+			const baseTime = 1 / 50000
+			const singleRolloverTimestamp = '2021-07-02T18:13:43.896Z' // add 2^33 / 50000 seconds to the timestamp
+			expect(getRolloverTimestamp(baseTimestamp, 1, baseTime))
+				.toEqual(singleRolloverTimestamp)
 		})
 	})
 })

--- a/packages/core/src/utils/__test__/mpegts.test.js
+++ b/packages/core/src/utils/__test__/mpegts.test.js
@@ -9,7 +9,7 @@ describe('mpegts utilities', () => {
 			expect(tsToMilliseconds(90000)).toBe(1000)
 		})
 		it('should convert successfuly with an override basetime', () => {
-			expect(tsToMilliseconds(500, 200)).toBe(2500)
+			expect(tsToMilliseconds(500, 1 / 200)).toBe(2500)
 		})
 	})
 

--- a/packages/core/src/utils/mpegts.js
+++ b/packages/core/src/utils/mpegts.js
@@ -1,3 +1,6 @@
+// MPEG-TS positions are stored as 1/90000'th of a second
+const DEFAULT_BASETIME = 1 / 90000
+
 /**
  * Converts a pts or dts extracted from an MPEG-TS packet to seconds.
  *
@@ -5,7 +8,10 @@
  * @param  {Number} baseTime The MPEG-TS basetime associated with the ts.
  * @return {Number}          The number of seconds represented by the pts or dts.
  */
-export const tsToMilliseconds = (ts, baseTime = 90000) => +((ts / baseTime) * 1000).toFixed(0)
+export function tsToMilliseconds(ts, baseTime = DEFAULT_BASETIME) {
+	const baseTimeMs = baseTime * 1000
+	return +(ts * baseTimeMs).toFixed(0)
+}
 
 /**
  * Exports a TSDemuxer MPEG-TS Packet as defined in the TSDemuxer project.


### PR DESCRIPTION
## Description
This PR adds support for PTS rollovers, which occur around every 26.5 hours (every `2^33 / 90` seconds).

Ingestion appliances that extend the `AbstractVideoIngestionAppliance` should see this support without any needed changes.

## Related Issues
Resolves #130 