### PR TITLE
Only track video streams

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `AbstractVideoIngestionAppliance` now only internally tracks the position of the video stream in a given MPEG-TS stream, as opposed to tracking all streams.
+
 ### Fixed
 - The optional `baseTime` parameter is now in terms of the fraction instead of the denominator of the fraction (e.g. `1/90000` instead of `90000`).
 - `AbstractVideoIngestionAppliance` now supports streams that have been running long enough for a PTS rollover to occur.

--- a/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
+++ b/packages/core/src/__test__/AbstractVideoIngestionAppliance.test.js
@@ -86,12 +86,12 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 			ingestionAppliance.mpegtsDemuxer = {
 				process: jest.fn(),
 			}
-			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({
-				pts: 90000,
-			})
+			const testData = loadTestData(__dirname, 'processMpegtsStreamData.json')
+			const videoPacket = testData[0]
+			ingestionAppliance.onDemuxedPacket(videoPacket)
 			const streamData = Buffer.from('testDataXYZ', 'utf8')
 			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
-				expect(result.position).toEqual(1000)
+				expect(result.position).toEqual(13946)
 			})
 		})
 		it('should correctly decorate the Payload createdAt', () => {
@@ -100,9 +100,9 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 			ingestionAppliance.mpegtsDemuxer = {
 				process: jest.fn(),
 			}
-			ingestionAppliance.getMostRecentDemuxedPacket = jest.fn().mockReturnValueOnce({
-				pts: 90000,
-			})
+			const testData = loadTestData(__dirname, 'processMpegtsStreamData.json')
+			const videoPacket = testData[0]
+			ingestionAppliance.onDemuxedPacket(videoPacket)
 			const streamData = Buffer.from('testDataXYZ', 'utf8')
 			ingestionAppliance.processMpegtsStreamData(streamData, null, (err, result) => {
 				expect(typeof result.createdAt).toBe('string')
@@ -130,26 +130,30 @@ describe('AbstractVideoIngestionAppliance #unit', () => {
 	describe('onDemuxedPacket', () => {
 		it('should register new packets as most recent', () => {
 			const testData = loadTestData(__dirname, 'onDemuxedPacket.json')
-			const demuxedPacket = testData[0]
-			const demuxedPacket2 = testData[1]
+			const videoPacket1 = testData[0]
+			const videoPacket2 = testData[1]
+			const audioPacket1 = testData[1]
 			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
-			ingestionAppliance.onDemuxedPacket(demuxedPacket)
-			ingestionAppliance.onDemuxedPacket(demuxedPacket2)
-			expect(ingestionAppliance.mostRecentDemuxedPacket).toEqual(demuxedPacket2)
+			ingestionAppliance.onDemuxedPacket(videoPacket1)
+			expect(ingestionAppliance.mostRecentDemuxedVideoPacket).toEqual(videoPacket1)
+			ingestionAppliance.onDemuxedPacket(videoPacket2)
+			expect(ingestionAppliance.mostRecentDemuxedVideoPacket).toEqual(videoPacket2)
+			ingestionAppliance.onDemuxedPacket(audioPacket1)
+			expect(ingestionAppliance.mostRecentDemuxedVideoPacket).toEqual(videoPacket2)
 		})
 	})
 
-	describe('getMostRecentDemuxedPacket', () => {
+	describe('getMostRecentDemuxedVideoPacket', () => {
 		it('should return the value in most recent demuxed packet', () => {
 			const testData = loadTestData(__dirname, 'getMostRecentDemuxedPacket.json')
-			const demuxedPacket = testData[0]
+			const videoPacket = testData[0]
 			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
-			ingestionAppliance.mostRecentDemuxedPacket = demuxedPacket
-			expect(ingestionAppliance.getMostRecentDemuxedPacket()).toEqual(demuxedPacket)
+			ingestionAppliance.onDemuxedPacket(videoPacket)
+			expect(ingestionAppliance.getMostRecentDemuxedVideoPacket()).toEqual(videoPacket)
 		})
 		it('should return null if nothing has been processed', () => {
 			const ingestionAppliance = new FullyImplementedVideoIngestionAppliance()
-			expect(ingestionAppliance.getMostRecentDemuxedPacket()).toBe(null)
+			expect(ingestionAppliance.getMostRecentDemuxedVideoPacket()).toBe(null)
 		})
 	})
 

--- a/packages/core/src/__test__/data/getMostRecentDemuxedPacket.json
+++ b/packages/core/src/__test__/data/getMostRecentDemuxedPacket.json
@@ -12,19 +12,5 @@
     "type": 1,
     "content_type": 2,
     "frame_num": 377
-  },
-  {
-    "data": [
-      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
-    ],
-    "pts": 1255128,
-    "dts": 1252125,
-    "frame_ticks": 3003,
-    "program": 1,
-    "stream_number": 1,
-    "stream_id": 224,
-    "type": 1,
-    "content_type": 2,
-    "frame_num": 378
   }
 ]

--- a/packages/core/src/__test__/data/onDemuxedPacket.json
+++ b/packages/core/src/__test__/data/onDemuxedPacket.json
@@ -12,5 +12,33 @@
     "type": 1,
     "content_type": 2,
     "frame_num": 377
+  },
+  {
+    "data": [
+      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
+    ],
+    "pts": 1255128,
+    "dts": 1252125,
+    "frame_ticks": 3003,
+    "program": 1,
+    "stream_number": 1,
+    "stream_id": 224,
+    "type": 1,
+    "content_type": 2,
+    "frame_num": 378
+  },
+  {
+    "data": [
+      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
+    ],
+    "pts": 1255127,
+    "dts": 1252124,
+    "frame_ticks": 3003,
+    "program": 1,
+    "stream_number": 1,
+    "stream_id": 224,
+    "type": 1,
+    "content_type": 1,
+    "frame_num": 378
   }
 ]

--- a/packages/core/src/__test__/data/processMpegtsStreamData.json
+++ b/packages/core/src/__test__/data/processMpegtsStreamData.json
@@ -1,0 +1,16 @@
+[
+  {
+    "data": [
+      0, 0, 1, 0, 0, 215, 255, 251, 128, 0, 0, 1
+    ],
+    "pts": 1255128,
+    "dts": 1252125,
+    "frame_ticks": 3003,
+    "program": 1,
+    "stream_number": 1,
+    "stream_id": 224,
+    "type": 1,
+    "content_type": 2,
+    "frame_num": 377
+  }
+]


### PR DESCRIPTION
## Description
This PR fixes an issue where both video and audio stream positions were tracked, resulting in false rollovers.

## Related Issues
Resolves #132 