### PR TITLE
Update appliance-core for ingestion appliances

### DIFF
--- a/packages/video-file-ingestion/CHANGELOG.md
+++ b/packages/video-file-ingestion/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@tvkitchen/appliance-core` to version `0.7.1`.
 
 ## [0.3.2] - 2021-05-13
+### Changed
 - Update `@tvkitchen/appliance-core` to version `0.7.0`.
 
 ## [0.3.1] - 2021-04-21

--- a/packages/video-file-ingestion/package.json
+++ b/packages/video-file-ingestion/package.json
@@ -21,7 +21,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.7.0"
+    "@tvkitchen/appliance-core": "0.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/video-http-ingestion/CHANGELOG.md
+++ b/packages/video-http-ingestion/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@tvkitchen/appliance-core` to version `0.7.1`.
 
 ## [0.3.2] - 2021-05-13
+### Changed
 - Update `@tvkitchen/appliance-core` to version `0.7.0`.
 
 ## [0.3.1] - 2021-04-21

--- a/packages/video-http-ingestion/package.json
+++ b/packages/video-http-ingestion/package.json
@@ -24,7 +24,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@tvkitchen/appliance-core": "0.7.0",
+    "@tvkitchen/appliance-core": "0.7.1",
     "node-fetch": "^2.6.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,18 @@
   dependencies:
     type-detect "4.0.8"
 
+"@tvkitchen/appliance-core@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/appliance-core/-/appliance-core-0.7.0.tgz#6033584ac357967dde6e52d1ae624c0645823fa7"
+  integrity sha512-NgHnKZmCIdRwdMjfJi320ityJ5TAYxG47+1VtlS2xpuMHZTo7yPvh76Eo+CW959j752ds+NViQgPwSWLqn+9hA==
+  dependencies:
+    "@tvkitchen/base-classes" "^2.0.0-alpha.1"
+    "@tvkitchen/base-constants" "^1.2.0"
+    "@tvkitchen/base-errors" "^1.0.1"
+    "@tvkitchen/base-interfaces" "4.0.0-alpha.4"
+    command-exists "^1.2.9"
+    mpegts-demuxer "0.1.0"
+
 "@tvkitchen/base-classes@2.0.0-alpha.1", "@tvkitchen/base-classes@^2.0.0-alpha.1":
   version "2.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-2.0.0-alpha.1.tgz#a52e7d39ee814c1a9f9293e199f99a93adb4a0c8"


### PR DESCRIPTION
## Description
This PR updates the appliance core to `v0.7.1` for ingestion appliances in order to benefit from the PTS rollover logic.

## Related Issues
Related to #130 
