### PR TITLE
Support dynamic input / output types

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `AbstractAppliance` now passes the instance's settings to the `getInputTypes` method when determining a payload's validity.  This allows appliances to define configurable input and output types.
 
 ## [0.8.0] - 2020-07-02
 - The `AbstractVideoIngestionAppliance` is now renamed to `AbstractVideoReceiverAppliance`.

--- a/packages/core/src/AbstractAppliance.js
+++ b/packages/core/src/AbstractAppliance.js
@@ -43,7 +43,7 @@ class AbstractAppliance extends IAppliance {
 	/** @inheritdoc */
 	async isValidPayload(payload) {
 		assert(
-			this.constructor.getInputTypes().includes(payload.type),
+			this.constructor.getInputTypes(this.settings).includes(payload.type),
 			`${payload.type} is not a valid Payload type for this appliance.`,
 		)
 		return true

--- a/packages/core/src/__test__/AbstractAppliance.test.js
+++ b/packages/core/src/__test__/AbstractAppliance.test.js
@@ -10,6 +10,7 @@ import {
 } from '@tvkitchen/base-classes'
 import { AbstractAppliance } from '../AbstractAppliance'
 import {
+	DynamicTypeAppliance,
 	FullyImplementedAppliance,
 	PartiallyImplementedAppliance,
 } from './classes'
@@ -39,10 +40,23 @@ describe('AbstractAppliance #unit', () => {
 			appliance.isValidPayload(payload)
 				.catch((err) => expect(err).toBeDefined())
 		})
+
 		it('should return true when passed a payload with a matching inputType', async () => {
 			const payload = new Payload({ type: 'FOO' })
 			const appliance = new FullyImplementedAppliance()
 			expect(await appliance.isValidPayload(payload)).toBe(true)
+		})
+
+		it('should handle dynamic payload types', async () => {
+			const payloadType = 'myType'
+			const payload = new Payload({ type: payloadType })
+			const wrongPayload = new Payload({ type: 'anotherType' })
+			const appliance = new DynamicTypeAppliance(
+				{ inputTypes: [payloadType] },
+			)
+			expect(await appliance.isValidPayload(payload)).toBe(true)
+			appliance.isValidPayload(wrongPayload)
+				.catch((err) => expect(err).toBeDefined())
 		})
 	})
 

--- a/packages/core/src/__test__/classes/DynamicTypeAppliance.js
+++ b/packages/core/src/__test__/classes/DynamicTypeAppliance.js
@@ -1,0 +1,14 @@
+import { AbstractAppliance } from '../../AbstractAppliance'
+
+export class DynamicTypeAppliance extends AbstractAppliance {
+	static getInputTypes(settings) {
+		return settings.inputTypes
+	}
+
+	static getOutputTypes(settings) {
+		return settings.outputTypes
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	async invoke(payloads) { return payloads }
+}

--- a/packages/core/src/__test__/classes/index.js
+++ b/packages/core/src/__test__/classes/index.js
@@ -1,6 +1,5 @@
-export { FullyImplementedAppliance } from './FullyImplementedAppliance'
-export { PartiallyImplementedAppliance } from './PartiallyImplementedAppliance'
-export { FullyImplementedVideoReceiverAppliance } from './FullyImplementedVideoReceiverAppliance'
-export {
-	PartiallyImplementedVideoReceiverAppliance,
-} from './PartiallyImplementedVideoReceiverAppliance'
+export * from './DynamicTypeAppliance'
+export * from './FullyImplementedAppliance'
+export * from './PartiallyImplementedAppliance'
+export * from './FullyImplementedVideoReceiverAppliance'
+export * from './PartiallyImplementedVideoReceiverAppliance'


### PR DESCRIPTION
This PR updates the AbstractAppliance's implementation of `isValidPayload` to pass the current instance's settings to the `getInputTypes` method.  The settings might be ignored, but by passing them it becomes possible for an appliance author to accept different payload types depending on the appliance's settings.

(This change will also need to be made in the countertop)

Related to #151 