### PR TITLE
Update base-interfaces to v4.0.0-alpha.5

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `AbstractAppliance` now passes the instance's settings to the `getInputTypes` method when determining a payload's validity.  This allows appliances to define configurable input and output types.
 
+### Changed
+- Update `@tvkitchen/base-interfaces` to version `4.0.0-alpha.5`.
+
 ## [0.8.0] - 2020-07-02
 - The `AbstractVideoIngestionAppliance` is now renamed to `AbstractVideoReceiverAppliance`.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "@tvkitchen/base-classes": "^2.0.0-alpha.1",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.1",
-    "@tvkitchen/base-interfaces": "4.0.0-alpha.4",
+    "@tvkitchen/base-interfaces": "4.0.0-alpha.5",
     "command-exists": "^1.2.9",
     "mpegts-demuxer": "0.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,6 +1064,13 @@
   dependencies:
     "@tvkitchen/base-errors" "^1.0.0"
 
+"@tvkitchen/base-interfaces@4.0.0-alpha.5":
+  version "4.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-interfaces/-/base-interfaces-4.0.0-alpha.5.tgz#bccd905bbb94b635f3ce4bb67123beee103e37c2"
+  integrity sha512-XbI4HwqMqve8Km5Cr9sGmbUluDE3dSPAj20796To38H7OW5mpv3pJJbNVrCTjiUJ1NIB7BHWmVf6/ENB1xuy8A==
+  dependencies:
+    "@tvkitchen/base-errors" "^1.0.0"
+
 "@types/babel__core@^7.1.7":
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"


### PR DESCRIPTION
This PR updates the version of the @tvkitchen/base-interfaces to latest.